### PR TITLE
Only accept documentation from src/ and docs/

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -864,7 +864,7 @@ WARN_LOGFILE           = docs/doxygen_warnings.txt
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = ./README.md ./src/ ./docs/ 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1061,7 +1061,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = ./README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Documentation Guidelines
 We utilize [Doxygen](https://www.doxygen.nl/index.html) to autogenerate documentation from your code. 
 
-Documentation from accepted code on `main` is hosted on github pages at [cu-robotics.github.io/firmware](cu-robotics.github.io/firmware). You can also compile the documentation locally by reading below.
+Documentation from accepted code on `main` is hosted on github pages at [cu-robotics.github.io/firmware](cu-robotics.github.io/firmware). You can also compile the documentation locally by reading below. Documentation will only be generated for files within [src/](../src/) and [docs/](../docs/) directories.
 
 This README describe how to install Doxygen, write documentation following our standards, and accessing your documentation once complete.
 


### PR DESCRIPTION
Now we will only attempt to document _our_ code and not external resources. 