### PR TITLE
Add githook-provided branch protection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# pre-commit githook, runs before a git commit is accepted.
+
+# branch protection githook inspired from https://stackoverflow.com/questions/75955185/is-there-a-way-to-protect-a-git-branch-locally
+# githook directory must be set locally in order for the hook to run.
+# set directory using: git config --local core.hooksPath <new_dir>
+
+current_branch="$(git branch --show-current)"
+
+# supports multiple protected branches. Add additional branches to for loop: for protected_branch in "branch1" "branch2" ... ; do
+for protected_branch in "main"; do 
+    if [[ "$protected_branch" == "$current_branch" ]]; then
+        echo "ERROR: local branch $current_branch is protected" 
+        exit 1
+    fi
+done
+
+exit 0

--- a/Makefile-githook
+++ b/Makefile-githook
@@ -1,0 +1,5 @@
+#!/usr/bin/make
+
+# Set githook path to .githooks/ (from ./git/hooks) so that they are tracked on the repository's version control.
+init:
+	git config --local core.hooksPath .githooks

--- a/Makefile-githook
+++ b/Makefile-githook
@@ -1,5 +1,7 @@
 #!/usr/bin/make
 
+# run with: make -f Makefile-githook init
+
 # Set githook path to .githooks/ (from ./git/hooks) so that they are tracked on the repository's version control.
 init:
 	git config --local core.hooksPath .githooks

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ To begin, download this repo: \
 git clone https://gitlab.com/cu-robotics/firmware.git
 ```
 
-Then, install dependencies: \
-`TODO`
+Then, install dependencies:
+
+`githooks` provide branch protection locally. Set the .githook/ directory with:
+```bash
+git config --local core.hooksPath .githooks
+```
 
 `buff-core` is required to build firmware. Clone the repo:
 ```bash


### PR DESCRIPTION
Adds a pre-commit githook to stop commits from happening on main locally. 

The githook(s) are located at .githooks/ . This directory needs to be set individually on each repository clone so the hook is tracked here on the repository, and then run by each person's local git.

This is set by 
```bash
git config --local core.hooksPath .githooks
```

I have put this in the main README.md, and in addition an init task in `Makefile-githooks`. In the future we should integrate it with a single Makefile setup/init task, but I do not know how our build script will work yet.