### PR TITLE
Downgrade doxygen to version provided in linux packages

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         # Run Doxygen Build
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@v1.9.5
+        uses: mattnotmitt/doxygen-action@v1.9.1
         with:
           doxyfile-path: ./Doxyfile # Docs build settings
           working-directory: .

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         # Run Doxygen Build
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@v1.9.5
+        uses: mattnotmitt/doxygen-action@v1.9.1
         with:
           doxyfile-path: ./Doxyfile # Docs build settings
           working-directory: .


### PR DESCRIPTION
From version 1.9.5 to version 1.9.1, removing bounding box errors