### PR TITLE
Attempt to deploy documentation pages even if documentation generation fails

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,7 @@ jobs:
           working-directory: .
           enable-latex: false # could enable latex later if needed, but it has a slow install.
       - name: Pages Deployment
+        if: success() || failure() # (Attempt to) deploy docs even if doxygen fails
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should still deploy our documentation even if there exists undocumented members, etc.

Will self-merge to test as this is a github actions change.