### PR TITLE
fixed freakouts, teensy loop was running too fast

### DIFF
--- a/src/controls/estimator.hpp
+++ b/src/controls/estimator.hpp
@@ -419,8 +419,15 @@ public:
         global_roll_velocity = __vectorProduct(roll_axis_global, raw_omega_vector, 3);
         // position integration
         dt = time.delta();
-        if (dt > .002)
-            dt = 0; // first dt loop generates huge time so check for that
+        
+        // chassis_angle = yaw_angle - yaw_enc_angle;
+        chassis_angle = -yaw_enc_angle;
+        if(count1 == 0){
+            initial_chassis_angle = chassis_angle;
+            prev_chassis_angle = chassis_angle;
+            count1++;
+            dt = 0;
+        }
         yaw_angle += current_yaw_velocity * (dt);
         pitch_angle += current_pitch_velocity * (dt);
         roll_angle += current_roll_velocity * (dt);
@@ -429,13 +436,6 @@ public:
         global_pitch_angle += -global_pitch_velocity * (dt);
         global_roll_angle += -global_roll_velocity * (dt);
 
-        // chassis_angle = yaw_angle - yaw_enc_angle;
-        chassis_angle = -yaw_enc_angle;
-        if(count1 == 0){
-            initial_chassis_angle = chassis_angle;
-            prev_chassis_angle = chassis_angle;
-            count1++;
-        }
 
         while (yaw_angle >= PI)
             yaw_angle -= 2 * PI;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,11 +289,12 @@ int main() {
             can.zero();
         }
 
-        for(int i = 0; i < 6; i++){
-            for(int j = 0; j < 3; j++){
-                Serial.print(temp_state[i][0]);
-                Serial.print(", ");
+        for (int i = 3; i < 5; i++) {
+            Serial.printf("[");
+            for (int j = 0; j < 2; j++) {
+                Serial.printf("%f ,", temp_state[i][j]);
             }
+            Serial.print("] ");
         }
 
         Serial.println();
@@ -304,7 +305,7 @@ int main() {
         loopc++;
 
         // Keep the loop running at the desired rate
-        //loop_timer.delay_micros((int)(1E6 / (float)(LOOP_FREQ)));
+        loop_timer.delay_micros((int)(1E6 / (float)(LOOP_FREQ)));
         float dt = stall_timer.delta();
         if (dt > 0.002) Serial.printf("Slow loop with dt: %f\n", dt);
     }


### PR DESCRIPTION
This fixed a freakout that was caused by our loops not running at 1 ms, but rather at 1/5 ms. 