### PR TITLE
Added buff encoder pins to yaml/comms

### DIFF
--- a/src/comms/config_layer.hpp
+++ b/src/comms/config_layer.hpp
@@ -36,7 +36,8 @@ static const std::map<std::string, u_int8_t> yaml_section_id_mappings = {
     {"switcher_values", 19},
     {"drive_conversion_factors", 20},
     {"governor_types", 21},
-    {"odom_values", 22}
+    {"odom_values", 22},
+    {"encoder_pins", 23}
 };
 
 /// @brief Handle seeking and reading configuration packets coming from khadas
@@ -136,6 +137,8 @@ struct Config {
     float odom_values[3];
     /// @brief switcher placement values
     float switcher_values[2];
+    /// @brief pin numbers on the teensy for the encoders
+    float encoder_pins[2];
 
     /// @brief fill all config data from packets
     /// @param packets CommsPacket array filled with data from yaml
@@ -233,6 +236,9 @@ struct Config {
             }
             if(id==yaml_section_id_mappings.at("encoder_offsets")){
                 memcpy(encoder_offsets, packets[i].raw + 8, sub_size);
+            }
+            if(id==yaml_section_id_mappings.at("encoder_pins")){
+                memcpy(encoder_pins, packets[i].raw + 8, sub_size);
             }
         }
     }

--- a/src/controls/estimator_manager.cpp
+++ b/src/controls/estimator_manager.cpp
@@ -1,12 +1,12 @@
 #include "estimator_manager.hpp"
 
 EstimatorManager::EstimatorManager(CANData* data, Config c_data) {
-    pinMode(YAW_BUFF_CS, OUTPUT);
-    pinMode(PITCH_BUFF_CS, OUTPUT);
-    pinMode(ICM_CS, OUTPUT);
+    for (int i = 0;i < c_data.num_sensors[0];i++) {
+        pinMode(c_data.encoder_pins[i], OUTPUT);
+        digitalWrite(c_data.encoder_pins[i], HIGH);
+    }
 
-    digitalWrite(YAW_BUFF_CS, HIGH);
-    digitalWrite(PITCH_BUFF_CS, HIGH);
+    pinMode(ICM_CS, OUTPUT);
     digitalWrite(ICM_CS, HIGH);
 
     Serial.println("Starting SPI");
@@ -15,8 +15,7 @@ EstimatorManager::EstimatorManager(CANData* data, Config c_data) {
 
     //buff enc loop
     for(int i = 0;i < c_data.num_sensors[0];i++){
-        //yaw buff enc - 1 is the same value as the pitch enc
-        buff_sensors[i].init(YAW_BUFF_CS-i);
+        buff_sensors[i].init(c_data.encoder_pins[i]);
     }
     //imu loop
     for(int i = 0;i < c_data.num_sensors[1];i++){


### PR DESCRIPTION
Allowed for yaw and pitch buff encoder pins to be specified in the yaml and read in firmware.
