### PR TITLE
add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2023-2024 CU Robotics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
After approval from the president @BananaBuff, this PR adds the [MIT License](https://en.wikipedia.org/wiki/MIT_License#License_terms).

The primary purpose of this is to ensure we are allowed to use the code we write in this club even after we graduate (with attribution), in case we want to use/reference/learn from it later. For this (already public) repo it also welcomes others to reference/use the code.

Note that this license requires attribution. Other licenses like [MIT-0](https://en.wikipedia.org/wiki/MIT_License#MIT_No_Attribution_License) or [BSD Zero Clause](https://en.wikipedia.org/wiki/BSD_licenses#0-clause) would not, in case we want those instead.

I ask that @BananaBuff re-approves this and performs the merge as the president of the club.