### PR TITLE
updated tytools install to use sudo for curl

### DIFF
--- a/tools/install_tytools.sh
+++ b/tools/install_tytools.sh
@@ -2,7 +2,7 @@
 sudo mkdir -p -m0755 /etc/apt/keyrings
 
 # downloads the key for the repo for apt to install from
-curl https://download.koromix.dev/debian/koromix-archive-keyring.gpg -o /etc/apt/keyrings/koromix-archive-keyring.gpg
+sudo curl https://download.koromix.dev/debian/koromix-archive-keyring.gpg -o /etc/apt/keyrings/koromix-archive-keyring.gpg
 
 # adds the repo to the apt list
 echo "deb [signed-by=/etc/apt/keyrings/koromix-archive-keyring.gpg] https://download.koromix.dev/debian stable main" | sudo tee /etc/apt/sources.list.d/koromix.dev-stable.list

--- a/tools/install_tytools.sh
+++ b/tools/install_tytools.sh
@@ -1,3 +1,6 @@
+# install dependencies (curl)
+sudo apt install curl
+
 # makes the keyrings directory with correct permission
 sudo mkdir -p -m0755 /etc/apt/keyrings
 


### PR DESCRIPTION
tytools install script provides errors on some systems if `sudo curl` is not used; corrected