### PR TITLE
Move tty id finding to get_tty_path.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ upload: build
 	@echo [Uploading] - If this fails, press the button on the teensy and re-run make upload
 	@tycmd upload $(PROJECT_NAME).hex
 # Teensy serial isn't immediately available after upload, so we wait a bit
-	@sleep 0.25s
+# The teensy waits for 20 + 280 + 20 ms after power up/boot
+	@sleep 0.4s
 	@bash tools/monitor.sh
 
 # # # Clean Targets # # #

--- a/tools/get_tty_path.sh
+++ b/tools/get_tty_path.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This finds the correct ttyACM device. First argument passed in should be the device ID.
+# Example usage: tty_path=$(./tools/get_tty_path.sh *-f00)
+
+# Device id, passed in as first argument with $1.
+tty_id=$1
+
+# path to the /dev/ serial device that the Teensy is connected to
+tty_path=""
+
+# if no first argument provided
+if [ ! -n "$tty_id" ]; then
+    # 1>&2 redirects stdout (1) into stderr (2)
+    echo "\"$1\" is not a valid tty ID" 1>&2
+    exit 1
+fi
+
+# Find the correct serial device
+# The important part is the ID/interface number at the end, which is compared here
+for i in /dev/serial/by-id/*; do
+    # compare with first argument passed to this command
+	if [[ "$i" == $tty_id ]]; then
+		tty_path=$i
+		break
+	fi
+done
+
+# found the id, now we need the actual path to the specific ttyACM device
+if [ -n "$tty_path" ]; then
+	tty_path=$(readlink -f $tty_path)
+fi
+
+# if no tty path found
+if [ ! -n "$tty_path" ]; then
+    # 1>&2 redirects stdout (1) into stderr (2)
+    echo "Failed to find the correct serial device for Teensy with tty_id '$tty_id' " 1>&2
+    echo "This probably means the Teensy is not connected or the Teensy is in bootloader mode (red LED on/blinking)" 1>&2
+
+    exit 1
+fi
+
+echo $tty_path # outputs to stdout by default
+
+exit 0

--- a/tools/monitor.sh
+++ b/tools/monitor.sh
@@ -1,5 +1,4 @@
-# path to the /dev/ serial device that the Teensy is connected to
-tty_path=""
+#!/bin/bash
 
 # handle sigint in a strange way to not break tycmd monitor
 trap 'exit 0' INT;
@@ -9,18 +8,7 @@ trap 'exit 0' INT;
 # where * is a number
 # The important part is the "if00" at the end, its interface number 00
 
-# Find the correct serial device
-for i in /dev/serial/by-id/*; do
-	if [[ "$i" == *-if00 ]]; then
-		tty_path=$i
-		break
-	fi
-done
-
-# found the id, now we need the actual path to the specific ttyACM device
-if [ -n "$tty_path" ]; then
-	tty_path=$(readlink -f $tty_path)
-fi
+tty_path=$(./tools/get_tty_path.sh *-if00)
 
 # If the tty path is not empty, we can start the monitor
 if [ -n "$tty_path" ]; then
@@ -32,8 +20,7 @@ if [ -n "$tty_path" ]; then
 	exit 0
 else
 	# failed to find the correct serial device
-	echo "Failed to monitor: Could not find the correct serial device for Teensy"
-	echo "This probably means the Teensy is not connected or the Teensy is in bootloader mode (red LED on/blinking)"
+	echo "Failed to monitor."
 
 	exit 1
 fi

--- a/tools/prepare_gdb.sh
+++ b/tools/prepare_gdb.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This finds the correct ttyACM device and puts it into gdb_commands.txt
 
 # The correct serial device has the following name
@@ -6,20 +8,7 @@
 # The important part is the "if02" at the end, its interface number 02
 # SerialUSB1 is what interface 02 references
 
-tty_path=""
-
-# Find the correct serial device
-for i in /dev/serial/by-id/*; do
-	if [[ "$i" == *-if02 ]]; then
-		tty_path=$i
-		break
-	fi
-done
-
-# found the id, now we need the actual path to the specific ttyACM device
-if [ -n "$tty_path" ]; then
-	tty_path=$(readlink -f $tty_path)
-fi
+tty_path=$(./tools/get_tty_path.sh *-if02)
 
 # Now we put it into gdb_commands.txt
 if [ -n "$tty_path" ]; then
@@ -27,8 +16,7 @@ if [ -n "$tty_path" ]; then
 	
 	exit 0
 else
-	echo "Failed to find the correct serial device for Teensy"
-	echo "This probably means the Teensy is not connected or the Teensy is in bootloader mode (red LED on/blinking)"
+	echo "Failed to prepare gdb"
 
 	exit 1
 fi


### PR DESCRIPTION
This reduces duplicate code in `monitor.sh` and `prepare_gdb.sh`, improving maintainability.
Code nearly identical to what was discussed in PR #65. 

I'm not able to test the success case without a teensy, but the failure cases have been tested at least. Should verify it works with a teensy before merging.