### PR TITLE
Made the readme have a capital F

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# firmware 
+# Firmware 
 This repo contains the source code for the CU Boulder Robotics Teams' microcontroller firmware. It runs on a PJRC Teensy 4.1 and interfaces with any device running `hive`.
 
 # Documentation


### PR DESCRIPTION
I propose renaming the repository from firmware to Firmware. I know, I know—this might seem like one of those "does the capitalization really matter?" moments, but hear me out.

Renaming clarifies that 'Firmware' is a proper noun, representing the project specifically. On a team called CU-Robotics (note the capital R), it only makes sense to give our beloved firmware the same level of dignity. Plus, a repository named 'Firmware' looks more professional and consistent than 'firmware', which could easily be interpreted as generic. This professional image is particularly important when presenting the project to sponsors, as it demonstrates attention to detail and a well-organized approach.

When referenced in documentation or conversation, 'Firmware' stands out more clearly as the name of the project rather than just a generic term. Renaming will help establish a clearer identity for the project, reinforcing its importance and ensuring consistency.

I also think there is an argument to be made about the naming of the hive repo as well. Are we talking about a hive of bees or Hive, the state-of-the-art robot controller platform?!