### PR TITLE
Clear DMAMEM section for profiler when it is constructed.

### DIFF
--- a/src/utils/profiler.cpp
+++ b/src/utils/profiler.cpp
@@ -3,6 +3,16 @@
 /// @brief Array of profiling sections.
 static DMAMEM Profiler::profiler_section_t sections[PROF_MAX_SECTIONS] = { 0 };
 
+
+void Profiler::clear() {
+#ifdef PROFILE
+    for (auto& sec : sections) {
+        // initialize each section so the sections arent filled with DMAMEM junk
+        sec = profiler_section_t();
+    }
+#endif
+}
+
 void Profiler::begin(const char* name) {
 #ifdef PROFILE
     // search for a section by name or an empty slot
@@ -65,7 +75,7 @@ void Profiler::print(const char* name) {
             if (delta > max) max = delta;
         }
         // print stats
-        Serial.printf("Profiling for: %s\n  Min: %u us\n  Max: %u us\n  Avg: %u us\n", 
+        Serial.printf("Profiling for: %s\n  Min: %u us\n  Max: %u us\n  Avg: %u us\n",
                         name, min, max, sum / actual_count);
         return;
     }

--- a/src/utils/profiler.hpp
+++ b/src/utils/profiler.hpp
@@ -12,6 +12,11 @@
 
 /// @brief Object for profiling sections of code.
 struct Profiler {
+    /// @brief Constructor for the profiler.
+    Profiler() {
+        clear();
+    }
+
     /// @brief Data structure for a profiling section. 
     struct profiler_section_t {
         /// @brief Start time for each profiling section.
@@ -27,6 +32,9 @@ struct Profiler {
         /// @brief A unique name to identify the section.
         char name[PROF_MAX_NAME + 1] = { 0 };  // extra for null terminator
     };
+
+    /// @brief  Clear all profiling sections.
+    void clear();
 
     /// @brief Start a profiling section.
     /// @param name A unique name to identify the section.


### PR DESCRIPTION
Added clear() to constructor, that clears junk from DMAMEM when the profiler is constructed.

