### PR TITLE
Patch monitor.c on mac

### DIFF
--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -9,13 +9,13 @@
 #include <fts.h>            // FTS stuff
 
 /// @brief Max path size for the serial device
-#define PATH_MAX 4096
+#define SERIAL_PATH_MAX 4096
 
 /// @brief Size of the serial buffers
 const size_t read_size = 8ul * 1024ul;
 
 /// @brief Max size of the serial path, - 1 for null terminator
-const size_t SERIAL_PATH_SIZE = PATH_MAX - 1;
+const size_t SERIAL_PATH_SIZE = SERIAL_PATH_MAX - 1;
 
 /// @brief In serial buffer
 char* in_buffer = NULL;


### PR DESCRIPTION
To avoid naming conflict with macOS sdk, rename PATH_MAX to SERIAL_PATH_MAX in monitor.c

./tools/monitor.c:12:9: error: 'PATH_MAX' macro redefined [-Werror,-Wmacro-redefined]
   12 | #define PATH_MAX 4096
      |         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/syslimits.h:103:9: note: previous definition is here
  103 | #define PATH_MAX                 1024   /* max bytes in pathname */
      |         ^
1 error generated.