### PR TITLE
bumped bytes to 1.11.1 for dependabot alert

### DIFF
--- a/tools/waggle-interceptor/Cargo.lock
+++ b/tools/waggle-interceptor/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
Patches https://rustsec.org/advisories/RUSTSEC-2026-0007.html
