### PR TITLE
Improve clangd support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
-ColumnLimit: 0
+ColumnLimit: 99999

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
-ColumnLimit: 120
+ColumnLimit: 0

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Remove: [--specs=*]

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ build/
 # Ignore clangd files
 compile_commands.json
 .cache/
-.clangd
 
 # Ignore any tools/ directory artifacts
 tools/*.txt

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ MAKEFLAGS += -j$(nproc)
 
 
 # Main build target; depends on the target executable and git scraper
-build: $(BUILD_DIR)/$(TARGET_EXEC)
+build: clangd $(BUILD_DIR)/$(TARGET_EXEC)
 
 # Final linking step to create the executable.
 # This rule links all the object files to produce the final ELF executable.
@@ -188,6 +188,7 @@ docs: build
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf $(TARGET_EXEC).elf $(TARGET_EXEC).hex $(TARGET_EXEC).map $(TARGET_EXEC).dump
+	rm -f compile_commands.json
 
 # Clean only the source object files
 clean_src:

--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,14 @@ help:
 
 
 # Generate compile_commands.json from the Makefile's flags and source lists.
-.PHONY: clangd
+COMPILE_DB = compile_commands.json
 COMPILE_DB_SCRIPT = $(TOOLS_DIR)/generate_compile_commands.sh
-clangd:
+COMPILE_DB_DIR_DEPS = $(SRC_INC_DIRS) $(LIBRARY_INC_DIRS) $(TEENSY_INC_DIRS)
+
+.PHONY: clangd
+clangd: $(COMPILE_DB)
+
+$(COMPILE_DB): Makefile $(COMPILE_DB_SCRIPT) $(COMPILE_DB_DIR_DEPS)
 	@CURDIR="$(CURDIR)" \
 	BUILD_DIR="$(BUILD_DIR)" \
 	COMPILER_CPP="$(COMPILER_CPP)" \

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ endif
 
 # Base arm-none-eabi and Teensyduino tool paths
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
+TARGET_TRIPLE ?= arm-none-eabi
 
 # arm-none-eabi tools
 COMPILER_CPP	= $(COMPILER_TOOLS_PATH)/arm-none-eabi-g++
@@ -259,58 +260,32 @@ restart:
 help: 
 	@echo "Basic usage: make [target]"
 	@echo "Targets:"
-	@echo "  install:      installs all required dependencies"
-	@echo "  build:        compiles the source code and links with libraries"
-	@echo "  upload:       builds the source and uploads it to the Teensy"
-	@echo "  gdb:          starts GDB and attaches to the firmware running on a connected Teensy"
-	@echo "  monitor:      monitors any actively running firmware and displays serial output"
-	@echo "  kill:         stops any running firmware"
-	@echo "  restart:      restarts any running firmware"
-	@echo "  clean:        removes all build artifacts and generated files"
-	@echo "  clean_src:    removes only the source object files"
-	@echo "  clean_libs:   removes only the library object files"
+	@echo "  install:       installs all required dependencies"
+	@echo "  build:         compiles the source code and links with libraries"
+	@echo "  upload:        builds the source and uploads it to the Teensy"
+	@echo "  gdb:           starts GDB and attaches to the firmware running on a connected Teensy"
+	@echo "  monitor:       monitors any actively running firmware and displays serial output"
+	@echo "  kill:          stops any running firmware"
+	@echo "  restart:       restarts any running firmware"
+	@echo "  clean:         removes all build artifacts and generated files"
+	@echo "  clean_src:     removes only the source object files"
+	@echo "  clean_libs:    removes only the library object files"
 	@echo "  clean_teensy4: removes only the Teensy object files"
-	@echo "  cdb: 		   generates compile_commands.json for clangd using Bear"
-	@echo "  docs:         generates documentation of our src/ code using Doxygen"
+	@echo "  clangd:        generates compile_commands.json for clangd"
+	@echo "  docs:          generates documentation of our src/ code using Doxygen"
 
-# --- Compile DB generation with Bear -----------------------------------------
-.PHONY: cdb
 
-# Directory to host wrapper symlinks
-BEAR_WRAPDIR ?= .bearwrap
-
-# Try to find Bear's wrapper path on common installs
-# 1) Homebrew (stable path via /opt, not versioned Cellar)
-BEAR_WRAPPER ?= $(shell brew --prefix bear 2>/dev/null)/lib/bear/wrapper
-# 2) Fallbacks for typical Linux layouts
-ifeq ($(wildcard $(BEAR_WRAPPER)),)
-  BEAR_WRAPPER := /usr/lib/bear/wrapper
-endif
-ifeq ($(wildcard $(BEAR_WRAPPER)),)
-  BEAR_WRAPPER := /usr/lib/x86_64-linux-gnu/bear/wrapper
-endif
-
-# Run this target to generate compile_commands.json for clangd.
-# To make clangd parse our project correctly, configure extra args:
-# * --query-driver=/path/to/compiler so it trusts the cross-compiler in firmware/tools/compiler/arm-gnu-toolchain/bin
-# * --compile-args=-isystem./teensy4 and --compile-args=-isystem./libraries to silence errors in external headers
-# Add these in your IDE's clangd settings (e.g. .vscode/settings.json, .zed/settings.json, etc.).
-cdb:
-	@command -v bear >/dev/null || { echo "Error: bear not found in PATH"; exit 1; }
-	@test -x "$(BEAR_WRAPPER)" || { echo "Error: bear wrapper not found at $(BEAR_WRAPPER)"; exit 1; }
-	@echo "[cdb] Preparing Bear wrapper links in $(BEAR_WRAPDIR)"
-	@rm -f compile_commands.json compile_commands.events.json
-	@mkdir -p $(BEAR_WRAPDIR)
-	# Create wrapper symlinks named like your cross-compilers:
-	@ln -sf "$(BEAR_WRAPPER)" "$(BEAR_WRAPDIR)/arm-none-eabi-g++"
-	@ln -sf "$(BEAR_WRAPPER)" "$(BEAR_WRAPDIR)/arm-none-eabi-gcc"
-	# Put toolchain bin in PATH so the wrapper can find the real compilers,
-	# and ask Bear to put $(BEAR_WRAPDIR) at the *front* of PATH for interception.
-	@echo "[cdb] Running build through Bear to capture commands"
-	@PATH="$(COMPILER_TOOLS_PATH):$$PATH" \
-	bear --wrapper-dir "$(BEAR_WRAPDIR)" -- \
-	  $(MAKE) -B build \
-	  COMPILER_CPP=arm-none-eabi-g++ \
-	  COMPILER_C=arm-none-eabi-gcc
-	@{ command -v jq >/dev/null && jq 'length' compile_commands.json; } >/dev/null 2>&1 || true
-	@echo "[cdb] Done: compile_commands.json generated"
+# Generate compile_commands.json from the Makefile's flags and source lists.
+.PHONY: clangd
+COMPILE_DB_SCRIPT = $(TOOLS_DIR)/generate_compile_commands.sh
+clangd:
+	@CURDIR="$(CURDIR)" \
+	BUILD_DIR="$(BUILD_DIR)" \
+	COMPILER_CPP="$(COMPILER_CPP)" \
+	COMPILER_C="$(COMPILER_C)" \
+	TARGET_TRIPLE="$(TARGET_TRIPLE)" \
+	CPPFLAGS='$(CPPFLAGS)' \
+	CXXFLAGS='$(CXXFLAGS)' \
+	CFLAGS='$(CFLAGS)' \
+	SRC_FILES='$(SRC_SRC) $(LIBRARY_SRC) $(TEENSY_SRC)' \
+	"$(COMPILE_DB_SCRIPT)"

--- a/src/comms/ethernet_comms.hpp
+++ b/src/comms/ethernet_comms.hpp
@@ -10,7 +10,7 @@ namespace qn = qindesign::network;
 
 // DEBUG define for displaying all comms errors/status updates
 // This is very noisy on start up
-#define COMMS_DEBUG
+// #define COMMS_DEBUG
 
 namespace Comms {
 

--- a/src/controls/controller.hpp
+++ b/src/controls/controller.hpp
@@ -25,6 +25,9 @@ public:
     /// @param _controller_config config data for this controller
     Controller(const Cfg::Controller& _controller_config) : controller_config(_controller_config) { };
 
+    /// @brief Virtual destructor since this is a parent class
+    virtual ~Controller() { };
+
     /// @brief sends motor commands based on a reference and estimated state
     /// @param reference_map current target robot state map
     /// @param estimate_map current estimate robot state map

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+json_escape() {
+    local s="${1//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+get_system_includes() {
+    local compiler="$1"
+    local language="$2"
+
+    "$compiler" -E -x "$language" - -v < /dev/null 2>&1 \
+        | awk '
+            /#include <...> search starts here:/ { in_list=1; next }
+            /End of search list./ { exit }
+            in_list {
+                sub(/^[[:space:]]+/, "", $0)
+                if (length($0) > 0) {
+                    print $0
+                }
+            }
+        '
+}
+
+: "${CURDIR:?CURDIR is required}"
+: "${BUILD_DIR:?BUILD_DIR is required}"
+: "${COMPILER_CPP:?COMPILER_CPP is required}"
+: "${COMPILER_C:?COMPILER_C is required}"
+: "${TARGET_TRIPLE:=arm-none-eabi}"
+: "${CPPFLAGS:?CPPFLAGS is required}"
+: "${CXXFLAGS:?CXXFLAGS is required}"
+: "${CFLAGS:?CFLAGS is required}"
+: "${SRC_FILES:?SRC_FILES is required}"
+
+echo "[compile-db] Generating compile_commands.json"
+
+if [[ ! -x "$COMPILER_CPP" ]]; then
+    echo "Error: C++ compiler not found at $COMPILER_CPP" >&2
+    exit 1
+fi
+
+if [[ ! -x "$COMPILER_C" ]]; then
+    echo "Error: C compiler not found at $COMPILER_C" >&2
+    exit 1
+fi
+
+tmp_db="$(mktemp compile_commands.json.XXXXXX)"
+cleanup() {
+    rm -f "$tmp_db"
+}
+trap cleanup EXIT
+
+mapfile -t cxx_sys_includes < <(get_system_includes "$COMPILER_CPP" c++)
+mapfile -t c_sys_includes < <(get_system_includes "$COMPILER_C" c)
+read -r -a cppflags <<< "$CPPFLAGS"
+read -r -a cxxflags <<< "$CXXFLAGS"
+read -r -a cflags <<< "$CFLAGS"
+
+first=1
+entry_count=0
+
+exec 3> "$tmp_db"
+printf '[\n' >&3
+
+for src in $SRC_FILES; do
+    case "$src" in
+        *.cc|*.cpp|*.cxx)
+            compiler="$COMPILER_CPP"
+            flags=(--target="$TARGET_TRIPLE" "${cppflags[@]}" "${cxxflags[@]}")
+            sys_includes=("${cxx_sys_includes[@]}")
+            ;;
+        *.c)
+            compiler="$COMPILER_C"
+            flags=(--target="$TARGET_TRIPLE" "${cppflags[@]}" "${cflags[@]}")
+            sys_includes=("${c_sys_includes[@]}")
+            ;;
+        *)
+            continue
+            ;;
+    esac
+
+    obj="$BUILD_DIR/$src.o"
+    args=("$compiler" "${flags[@]}")
+    for include_dir in "${sys_includes[@]}"; do
+        args+=(-isystem "$include_dir")
+    done
+    args+=(-c "$src" -o "$obj")
+
+    if [[ $first -eq 0 ]]; then
+        printf ',\n' >&3
+    fi
+    first=0
+
+    printf '  {\n' >&3
+    printf '    "directory": "%s",\n' "$(json_escape "$CURDIR")" >&3
+    printf '    "file": "%s",\n' "$(json_escape "$src")" >&3
+    printf '    "output": "%s",\n' "$(json_escape "$obj")" >&3
+    printf ',\n' >&3
+    printf '    "arguments": [\n' >&3
+    for i in "${!args[@]}"; do
+        if [[ $i -gt 0 ]]; then
+            printf ',\n' >&3
+        fi
+        printf '      "%s"' "$(json_escape "${args[$i]}")" >&3
+    done
+    printf '\n    ]\n' >&3
+    printf '  }' >&3
+
+    entry_count=$((entry_count + 1))
+done
+
+printf '\n]\n' >&3
+exec 3>&-
+mv "$tmp_db" compile_commands.json
+trap - EXIT
+
+echo "[compile-db] Done: compile_commands.json generated with $entry_count entries"

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -38,7 +38,7 @@ get_system_includes() {
 : "${CFLAGS:?CFLAGS is required}"
 : "${SRC_FILES:?SRC_FILES is required}"
 
-echo "[compile-db] Generating compile_commands.json"
+echo "[Generating compile_commands.json]"
 
 if [[ ! -x "$COMPILER_CPP" ]]; then
     echo "Error: C++ compiler not found at $COMPILER_CPP" >&2
@@ -119,4 +119,4 @@ exec 3>&-
 mv "$tmp_db" compile_commands.json
 trap - EXIT
 
-echo "[compile-db] Done: compile_commands.json generated with $entry_count entries"
+echo "[compile_commands.json generated with $entry_count entries]"

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -101,15 +101,14 @@ for src in $SRC_FILES; do
     printf '    "directory": "%s",\n' "$(json_escape "$CURDIR")" >&3
     printf '    "file": "%s",\n' "$(json_escape "$src")" >&3
     printf '    "output": "%s",\n' "$(json_escape "$obj")" >&3
-    printf ',\n' >&3
-    printf '    "arguments": [\n' >&3
+    printf '    "arguments": [' >&3
     for i in "${!args[@]}"; do
         if [[ $i -gt 0 ]]; then
-            printf ',\n' >&3
+            printf ', ' >&3
         fi
-        printf '      "%s"' "$(json_escape "${args[$i]}")" >&3
+        printf '"%s"' "$(json_escape "${args[$i]}")" >&3
     done
-    printf '\n    ]\n' >&3
+    printf ']\n' >&3
     printf '  }' >&3
 
     entry_count=$((entry_count + 1))

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
+JSON_ESCAPED=
+
 json_escape() {
-    local s="${1//\\/\\\\}"
-    s="${s//\"/\\\"}"
-    s="${s//$'\n'/\\n}"
-    s="${s//$'\r'/\\r}"
-    s="${s//$'\t'/\\t}"
-    printf '%s' "$s"
+    JSON_ESCAPED="${1//\\/\\\\}"
+    JSON_ESCAPED="${JSON_ESCAPED//\"/\\\"}"
+    JSON_ESCAPED="${JSON_ESCAPED//$'\n'/\\n}"
+    JSON_ESCAPED="${JSON_ESCAPED//$'\r'/\\r}"
+    JSON_ESCAPED="${JSON_ESCAPED//$'\t'/\\t}"
 }
 
 get_system_includes() {
@@ -70,6 +71,19 @@ read -r -a cppflags <<< "$CPPFLAGS"
 read -r -a cxxflags <<< "$CXXFLAGS"
 read -r -a cflags <<< "$CFLAGS"
 
+json_escape "$CURDIR"
+escaped_curdir="$JSON_ESCAPED"
+
+cxx_base_args=("$COMPILER_CPP" --target="$TARGET_TRIPLE" "${cppflags[@]}" "${cxxflags[@]}")
+for include_dir in "${cxx_sys_includes[@]}"; do
+    cxx_base_args+=(-isystem "$include_dir")
+done
+
+c_base_args=("$COMPILER_C" --target="$TARGET_TRIPLE" "${cppflags[@]}" "${cflags[@]}")
+for include_dir in "${c_sys_includes[@]}"; do
+    c_base_args+=(-isystem "$include_dir")
+done
+
 first=1
 entry_count=0
 
@@ -79,14 +93,10 @@ printf '[\n' >&3
 for src in $SRC_FILES; do
     case "$src" in
         *.cc|*.cpp|*.cxx)
-            compiler="$COMPILER_CPP"
-            flags=(--target="$TARGET_TRIPLE" "${cppflags[@]}" "${cxxflags[@]}")
-            sys_includes=("${cxx_sys_includes[@]}")
+            args=("${cxx_base_args[@]}")
             ;;
         *.c)
-            compiler="$COMPILER_C"
-            flags=(--target="$TARGET_TRIPLE" "${cppflags[@]}" "${cflags[@]}")
-            sys_includes=("${c_sys_includes[@]}")
+            args=("${c_base_args[@]}")
             ;;
         *)
             continue
@@ -94,10 +104,6 @@ for src in $SRC_FILES; do
     esac
 
     obj="$BUILD_DIR/$src.o"
-    args=("$compiler" "${flags[@]}")
-    for include_dir in "${sys_includes[@]}"; do
-        args+=(-isystem "$include_dir")
-    done
     args+=(-c "$src" -o "$obj")
 
     if [[ $first -eq 0 ]]; then
@@ -105,16 +111,22 @@ for src in $SRC_FILES; do
     fi
     first=0
 
+    json_escape "$src"
+    escaped_src="$JSON_ESCAPED"
+    json_escape "$obj"
+    escaped_obj="$JSON_ESCAPED"
+
     printf '  {\n' >&3
-    printf '    "directory": "%s",\n' "$(json_escape "$CURDIR")" >&3
-    printf '    "file": "%s",\n' "$(json_escape "$src")" >&3
-    printf '    "output": "%s",\n' "$(json_escape "$obj")" >&3
+    printf '    "directory": "%s",\n' "$escaped_curdir" >&3
+    printf '    "file": "%s",\n' "$escaped_src" >&3
+    printf '    "output": "%s",\n' "$escaped_obj" >&3
     printf '    "arguments": [' >&3
     for i in "${!args[@]}"; do
         if [[ $i -gt 0 ]]; then
             printf ', ' >&3
         fi
-        printf '"%s"' "$(json_escape "${args[$i]}")" >&3
+        json_escape "${args[$i]}"
+        printf '"%s"' "$JSON_ESCAPED" >&3
     done
     printf ']\n' >&3
     printf '  }' >&3

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -50,7 +50,7 @@ if [[ ! -x "$COMPILER_C" ]]; then
     exit 1
 fi
 
-tmp_db="$(mktemp compile_commands.json.XXXXXX)"
+tmp_db="$(mktemp "${TMPDIR:-/tmp}/compile_commands.json.XXXXXX")"
 cleanup() {
     rm -f "$tmp_db"
 }

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -56,8 +56,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mapfile -t cxx_sys_includes < <(get_system_includes "$COMPILER_CPP" c++)
-mapfile -t c_sys_includes < <(get_system_includes "$COMPILER_C" c)
+cxx_sys_includes=()
+while IFS= read -r line; do
+    cxx_sys_includes+=("$line")
+done < <(get_system_includes "$COMPILER_CPP" c++)
+
+c_sys_includes=()
+while IFS= read -r line; do
+    c_sys_includes+=("$line")
+done < <(get_system_includes "$COMPILER_C" c)
+
 read -r -a cppflags <<< "$CPPFLAGS"
 read -r -a cxxflags <<< "$CXXFLAGS"
 read -r -a cflags <<< "$CFLAGS"


### PR DESCRIPTION
Adds a bash script that generates a `compile_commands.json` for clangd directly from the Makefile's sources and flags. This removes the dependency on Bear and works more consistently.

Run it with `make clangd`. It also runs automatically during builds so that clangd keeps up with new edits.