### PR TITLE
Removed references to microstate

### DIFF
--- a/src/controls/controller.cpp
+++ b/src/controls/controller.cpp
@@ -156,7 +156,6 @@ void XDriveController::step(RobotStateMap& reference_map, RobotStateMap& estimat
             pid.kd = low_level_velocity_controller.gains.d;
             motor_outputs[i] = pid.filter(dt, true, false) * power_limit_ratio;
             drive_motors[i]->write_motor_torque(motor_outputs[i]);
-            // Serial.printf("motor %d error: %f output: %f\n", i, -micro_estimate[i][1] + motor_velocity[i], outputs[i]);
         }
     } else {
         Serial.printf("governor type not used for xdrive controller");

--- a/src/controls/estimator.hpp
+++ b/src/controls/estimator.hpp
@@ -250,7 +250,7 @@ public:
     void step_states(RobotStateMap& updated_state_map, const RobotStateMap& previous_state_map, int override);
 };
 
-/// @brief This estimator estimates our "micro" state which is stores all the motor velocities(in rad/s), whereas the other estimators estimate "macro" state which stores robot joints
+/// @brief Estimate the state of the feeder ball velocity based on the feeder encoder velocity.
 struct FeederEstimator : public Estimator {
     private:
         /// @brief delta time
@@ -285,7 +285,7 @@ struct FeederEstimator : public Estimator {
         void step_states(RobotStateMap& updated_state_map, const RobotStateMap& previous_state_map, int override) override;
 };
 
-/// @brief This estimator estimates our "micro" state which is stores all the motor velocities(in rad/s), whereas the other estimators estimate "macro" state which stores robot joints
+/// @brief Estimate the state of the feeder ball velocity for the lower feeder based on the feeder encoder velocity. This is separate from the main FeederEstimator because it has different config data and we want to be able to disable one without affecting the other.
 struct LowerFeederEstimator : public Estimator {
     private:
         /// @brief delta time

--- a/src/controls/estimator_manager.hpp
+++ b/src/controls/estimator_manager.hpp
@@ -4,7 +4,7 @@
 #include "estimator.hpp"
 #include "sensors/sensor_manager.hpp"
 
-/// @brief Manage all estimators for macro and micro state
+/// @brief Manage all estimators for robot state
 class EstimatorManager {
 private:
     /// @brief List of all estimators that are currently active


### PR DESCRIPTION
We don't use the macro and microstate concept anymore so these references should be removed.