### PR TITLE
State desync fr this time

### DIFF
--- a/src/comms/data/comms_data.hpp
+++ b/src/comms/data/comms_data.hpp
@@ -38,6 +38,7 @@ enum class TypeLabel : uint16_t {
     TransmitterConfig,
     StartStereoTrigger,
     StopStereoTrigger,
+    TestLatencyData,
 };
 
 /// @brief Converts a TypeLabel to a string.
@@ -108,6 +109,8 @@ inline std::string to_string(TypeLabel type_label) {
         return "StartStereoTrigger";
     case TypeLabel::StopStereoTrigger:
         return "StopStereoTrigger";
+    case TypeLabel::TestLatencyData:
+	return "TestLatencyData";
     // no default case, so the compiler will warn us if we forget a case
     }
 

--- a/src/comms/data/firmware_data.cpp
+++ b/src/comms/data/firmware_data.cpp
@@ -94,6 +94,11 @@ void FirmwareData::set_data(CommsData* data) {
         this->config_status_data = config_status_data;
         break;
     }
+ case TypeLabel::TestLatencyData: {
+        // place the data in the mega struct
+        latency_data = *static_cast<TestLatencyData*>(data);
+        break;
+    }
     default:
         safety::safety_procedure("FirmwareData::set_data: Invalid type label given to place in mega struct: %u", static_cast<uint16_t>(data->type_label));
     }

--- a/src/comms/data/firmware_data.hpp
+++ b/src/comms/data/firmware_data.hpp
@@ -29,6 +29,8 @@ struct FirmwareData {
     TestData test_data;
     /// @brief Big test data
     BigTestData big_test_data;
+    /// @brief Test Latency Data
+    TestLatencyData latency_data;
     
     /// @brief TargetState data
     TargetState temp_reference;

--- a/src/comms/data/hive_data.cpp
+++ b/src/comms/data/hive_data.cpp
@@ -122,6 +122,11 @@ void HiveData::set_data(CommsData* data) {
         Serial.printf("Stop stereo trigger for %u received\n", static_cast<uint32_t>(stop_trigger->camera_trigger_name));
         break;
     }
+    case TypeLabel::TestLatencyData: {
+	     TestLatencyData* latency_data_ = static_cast<TestLatencyData*>(data);
+	     memcpy(&latency_data, latency_data_, sizeof(TestLatencyData));
+	     break;
+     }
     default:
         safety::safety_procedure("HiveData::set_data: Invalid type label given to place in mega struct: %u\n", static_cast<uint32_t>(data->type_label));
     }

--- a/src/comms/data/hive_data.hpp
+++ b/src/comms/data/hive_data.hpp
@@ -16,6 +16,8 @@ struct HiveData {
     TestData test_data;
     /// @brief Big test data
     BigTestData big_test_data;
+	/// @brief data for measuring 2 way latency
+    TestLatencyData latency_data;
 
     /// @brief Target state received from Hive; This is used as a reference for firmware to follow using its reference governor, state estimator and controllers.
     TargetState target_state_data;

--- a/src/comms/data/stereo_cam_trigger_data.hpp
+++ b/src/comms/data/stereo_cam_trigger_data.hpp
@@ -15,6 +15,8 @@ struct StereoCamTriggerData : Comms::CommsData {
     Cfg::SensorName camera_trigger_name = Cfg::SensorName::UnsetSensorName;
     /// @brief the state of the robot at the time of stereo trigger
     State::Raw state[static_cast<size_t>(Cfg::StateName::StateNameCount)] = { {0, 0, 0} };
+    /// @brief the frame count of the camera frames that match with this state
+    int frame_count = 0;
 
     /// @brief Print the stereo camera trigger data to the serial console for debugging purposes.
     void print() const {

--- a/src/comms/data/test_data.hpp
+++ b/src/comms/data/test_data.hpp
@@ -29,6 +29,7 @@ struct BigTestData : Comms::CommsData {
     float blah[128] = { 0 };
 };
 
+/// @brief Struct used to measure the round trip latency of the comms system
 struct TestLatencyData : Comms::CommsData {
     TestLatencyData() : Comms::CommsData(Comms::TypeLabel::TestLatencyData, Comms::PhysicalMedium::Ethernet, Comms::Priority::High, sizeof(TestData)) {}
     /// @brief The time in micros when the packet was sent

--- a/src/comms/data/test_data.hpp
+++ b/src/comms/data/test_data.hpp
@@ -31,7 +31,7 @@ struct BigTestData : Comms::CommsData {
 
 /// @brief Struct used to measure the round trip latency of the comms system
 struct TestLatencyData : Comms::CommsData {
-    TestLatencyData() : Comms::CommsData(Comms::TypeLabel::TestLatencyData, Comms::PhysicalMedium::Ethernet, Comms::Priority::High, sizeof(TestData)) {}
+    TestLatencyData() : Comms::CommsData(Comms::TypeLabel::TestLatencyData, Comms::PhysicalMedium::Ethernet, Comms::Priority::High, sizeof(TestLatencyData)) {}
     /// @brief The time in micros when the packet was sent
     uint64_t current_time = 0;
     /// @brief the difference in time between the current time and the time that was contained in the last received packet

--- a/src/comms/data/test_data.hpp
+++ b/src/comms/data/test_data.hpp
@@ -28,3 +28,11 @@ struct BigTestData : Comms::CommsData {
     /// @brief a bunch of data
     float blah[128] = { 0 };
 };
+
+struct TestLatencyData : Comms::CommsData {
+    TestLatencyData() : Comms::CommsData(Comms::TypeLabel::TestLatencyData, Comms::PhysicalMedium::Ethernet, Comms::Priority::High, sizeof(TestData)) {}
+    /// @brief The time in micros when the packet was sent
+    uint64_t current_time = 0;
+    /// @brief the difference in time between the current time and the time that was contained in the last received packet
+    uint64_t time_since_last_received = 0;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,6 +278,13 @@ int main() {
         config_status_sendable.data.is_configured = comms_layer.is_configured() ? 1 : 0;
         config_status_sendable.send_to_comms();
 
+	if (false) { // Tests roundtrip comms latency. also needs to be set to true in hive.
+	    Comms::Sendable<TestLatencyData> latency_data;
+	    latency_data.data.current_time = micros();
+	    latency_data.data.time_since_last_received = micros() - comms_layer.get_hive_data().latency_data.current_time;
+	    latency_data.send_to_comms();
+	}
+
         comms_layer.run();
 
         bool is_slow_loop = false;

--- a/src/sensors/StereoCamTrigger.cpp
+++ b/src/sensors/StereoCamTrigger.cpp
@@ -17,9 +17,12 @@ void StereoCamTrigger::track_exposures() {
   digitalWrite(config.digital_trigger_pin_1, LOW);
   digitalWrite(config.digital_trigger_pin_2, LOW);
   
+  counter += 1;
+
   if(estimated_state_map_interrupt_safe != nullptr) {
     // copy the estimated state map to the local estimated state map
     estimated_state_map_interrupt_safe->fill_state_array(comms_data.state);
+    comms_data.frame_count = counter;
   }
 }
 
@@ -66,6 +69,8 @@ void StereoCamTrigger::read() {
     
     digitalWrite(config.camera_1_line_2_pin, LOW);
     digitalWrite(config.camera_2_line_2_pin, LOW);
+
+    counter = 0;
 
     Serial.printf("counter reset pin: %u triggered\n", config.camera_1_line_2_pin);
   }

--- a/src/sensors/StereoCamTrigger.cpp
+++ b/src/sensors/StereoCamTrigger.cpp
@@ -70,7 +70,7 @@ void StereoCamTrigger::read() {
     digitalWrite(config.camera_1_line_2_pin, LOW);
     digitalWrite(config.camera_2_line_2_pin, LOW);
 
-    counter = 0;
+    counter = -1;
 
     Serial.printf("counter reset pin: %u triggered\n", config.camera_1_line_2_pin);
   }

--- a/src/sensors/StereoCamTrigger.cpp
+++ b/src/sensors/StereoCamTrigger.cpp
@@ -81,6 +81,8 @@ void StereoCamTrigger::read() {
 void StereoCamTrigger::send_to_comms() const {
   Comms::Sendable<StereoCamTriggerData> sendable;
 
+  noInterrupts();
   sendable.data = comms_data;
+  interrupts();
   sendable.send_to_comms();
 }

--- a/src/sensors/StereoCamTrigger.hpp
+++ b/src/sensors/StereoCamTrigger.hpp
@@ -34,6 +34,9 @@ class StereoCamTrigger : public Sensor{
 
     /// @brief timestamp of the last time an exposure was triggered (last time signal was set to HIGH)
     volatile uint32_t latest_exposure_timestamp = 0;
+
+    /// @brief the number of frames that have been triggered since the last counter reset.
+    int counter = 0;
     
     /// @brief callback to pass to timer to update latest exposure timestamp
     void track_exposures();

--- a/src/sensors/StereoCamTrigger.hpp
+++ b/src/sensors/StereoCamTrigger.hpp
@@ -36,7 +36,7 @@ class StereoCamTrigger : public Sensor{
     volatile uint32_t latest_exposure_timestamp = 0;
 
     /// @brief the number of frames that have been triggered since the last counter reset.
-    int counter = 0;
+    int counter = -1;
     
     /// @brief callback to pass to timer to update latest exposure timestamp
     void track_exposures();

--- a/src/sensors/StereoCamTrigger.hpp
+++ b/src/sensors/StereoCamTrigger.hpp
@@ -36,7 +36,7 @@ class StereoCamTrigger : public Sensor{
     volatile uint32_t latest_exposure_timestamp = 0;
 
     /// @brief the number of frames that have been triggered since the last counter reset.
-    int counter = -1;
+   volatile int counter = -1;
     
     /// @brief callback to pass to timer to update latest exposure timestamp
     void track_exposures();


### PR DESCRIPTION
adds a counter that tracks the number of frames that have been triggered which is what we use to sync the robot state with a given camera frame.

Most of the code is actually a new comms packet that is used to test round trip latency of comms.