### PR TITLE
Improvements to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ compile_commands.json
 # Ignore any tools/ directory artifacts
 tools/*.txt
 tools/*.out
-tools/git_scraper
 tools/custom_monitor
 tools/compiler
 tools/tools

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ READELF			= $(COMPILER_TOOLS_PATH)/arm-none-eabi-readelf
 ADDR2LINE		= $(COMPILER_TOOLS_PATH)/arm-none-eabi-addr2line
 SIZE			= $(COMPILER_TOOLS_PATH)/arm-none-eabi-size
 
-GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
+GIT_SCRAPER_SRC = $(TOOLS_DIR)/git_scraper.cpp
+GIT_SCRAPER_BIN = $(BUILD_DIR)/git_scraper
 
 
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
@@ -140,10 +141,16 @@ clean:
 -include $(SRC_DEPS)
 
 
-git_scraper:
-	@g++ -std=gnu++17 $(GIT_SCRAPER) -o $(TOOLS_DIR)/git_scraper
-	@$(TOOLS_DIR)/git_scraper
-	@rm $(TOOLS_DIR)/git_scraper
+# The scraper itself is rebuilt only when its source changes, but it is run on
+# every build so it can pick up branch/commit changes. It rewrites
+# src/git_info.h only when the contents actually differ.
+$(GIT_SCRAPER_BIN): $(GIT_SCRAPER_SRC)
+	@mkdir -p $(dir $@)
+	@printf "HOSTCXX  %s\n" "$<"
+	@g++ -std=gnu++17 $< -o $@
+
+git_scraper: $(GIT_SCRAPER_BIN)
+	@$(GIT_SCRAPER_BIN)
 
 
 # Upload firmware to Teensy and start monitoring

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,6 @@ SIZE			= $(COMPILER_TOOLS_PATH)/arm-none-eabi-size
 # Path to the Git scraper tool source file
 GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 
-# Utilize all available CPU cores for parallel build
-MAKEFLAGS += -j$(nproc)
-
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
 
 build:	clangd $(BUILD_DIR)/$(TARGET_ELF)

--- a/Makefile
+++ b/Makefile
@@ -118,18 +118,12 @@ MAKEFLAGS += -j$(nproc)
 .PHONY: build
 
 
-# Main build target; depends on the target executable and git scraper
 build:	clangd $(BUILD_DIR)/$(TARGET_EXEC)
-# Final linking step to create the executable.
-# This rule links all the object files to produce the final ELF executable.
-# It depends on all object files and the 'git_scraper' target to ensure
-# that Git information is up-to-date before linking.
 $(BUILD_DIR)/$(TARGET_EXEC): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS) 
 	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LINKING_FLAGS) -o $(BUILD_DIR)/$(TARGET_EXEC).elf
-	@cp $(BUILD_DIR)/$(TARGET_EXEC).elf .
 	@echo [Constructing $(TARGET_EXEC).hex]
-	@$(OBJCOPY) -O ihex -R .eeprom $(TARGET_EXEC).elf $(TARGET_EXEC).hex
-	@chmod +x $(TARGET_EXEC).hex
+	@$(OBJCOPY) -O ihex -R .eeprom $(BUILD_DIR)/$(TARGET_EXEC).elf $(BUILD_DIR)/$(TARGET_EXEC).hex
+	@chmod +x $(BUILD_DIR)/$(TARGET_EXEC).hex
 	@$(OBJDUMP) -dstz $(BUILD_DIR)/$(TARGET_EXEC).elf > $(BUILD_DIR)/$(TARGET_EXEC).dump
 
 # Ensure git_scraper finishes before compiling any object files
@@ -164,7 +158,6 @@ docs: build
 # Clean the build directory and remove generated executables
 clean:
 	rm -rf $(BUILD_DIR)
-	rm -rf $(TARGET_EXEC).elf $(TARGET_EXEC).hex $(TARGET_EXEC).map $(TARGET_EXEC).dump
 	rm -f compile_commands.json
 
 # Clean only the source object files
@@ -196,7 +189,7 @@ git_scraper:
 # Upload the firmware to the Teensy device
 upload: build
 	@echo [Uploading] - If this fails, press the button on the teensy and re-run 'make upload'
-	@tycmd upload $(TARGET_EXEC).hex
+	@tycmd upload $(BUILD_DIR)/$(TARGET_EXEC).hex
 	@sleep 0.4s
 	@bash $(TOOLS_DIR)/monitor.sh
 
@@ -212,7 +205,7 @@ install:
 gdb:
 	@echo [Starting GDB]
 	@bash $(TOOLS_DIR)/prepare_gdb.sh
-	@$(GDB) -x $(TOOLS_DIR)/gdb_commands.txt --args $(TARGET_EXEC).elf
+	@$(GDB) -x $(TOOLS_DIR)/gdb_commands.txt --args $(BUILD_DIR)/$(TARGET_EXEC).elf
 
 
 # monitors currently running firmware on robot

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SRC_DEPS := $(SRC_OBJS:.o=.d)
 
 TEENSY_INC_DIRS := $(shell find $(TEENSY_SRC_DIRS) -type d)
 LIBRARY_INC_DIRS := $(shell find $(LIBRARY_SRC_DIRS) -maxdepth 2 -type d)
-SRC_INC_DIRS := $(shell find $(SRC_SRC_DIRS) -type d)
+SRC_INC_DIRS := $(SRC_SRC_DIRS)
 
 # -isystem on Teensy and Library files to suppress warnings
 TEENSY_INC_FLAGS := $(addprefix -isystem,$(TEENSY_INC_DIRS))

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET := firmware
 TARGET_ELF := $(BUILD_DIR)/$(TARGET).elf
 TARGET_HEX := $(BUILD_DIR)/$(TARGET).hex
 TARGET_MAP := $(BUILD_DIR)/$(TARGET).map
-TARGET_DUMP := $(BUILD_DIR)$(TARGET).dump
+TARGET_DUMP := $(BUILD_DIR)/$(TARGET).dump
 
 TEENSY_SRC_DIRS := teensy4
 LIBRARY_SRC_DIRS := libraries
@@ -86,18 +86,22 @@ GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
 
 
-build: $(TARGET_ELF)
+build: $(TARGET_HEX) $(TARGET_DUMP)
 
-$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
+$(TARGET_ELF): $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
 	@printf "LINK     %s\n" "$@"
 	@$(COMPILER_CPP) $(PROJECT_LDFLAGS) $(LDFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LDLIBS) -o $@
 
-	@printf "OBJCOPY  %s\n" "$(TARGET_HEX)"
-	@$(OBJCOPY) -O ihex -R .eeprom $@ $(TARGET_HEX)
-	@chmod +x $(TARGET_HEX)
 
-	@printf "OBJDUMP  %s\n" "$(TARGET_DUMP)"
-	@$(OBJDUMP) -dstz $@ > $(TARGET_DUMP)
+$(TARGET_HEX): $(TARGET_ELF)
+	@printf "OBJCOPY  %s\n" "$@"
+	@$(OBJCOPY) -O ihex -R .eeprom $< $@
+	@chmod +x $@
+
+
+$(TARGET_DUMP): $(TARGET_ELF)
+	@printf "OBJDUMP  %s\n" "$@"
+	@$(OBJDUMP) -dstz $< > $@
 
 
 # Ensure git_scraper finishes before compiling any object files

--- a/Makefile
+++ b/Makefile
@@ -51,32 +51,36 @@ LIBRARY_INC_FLAGS := $(addprefix -isystem,$(LIBRARY_INC_DIRS))
 SRC_INC_FLAGS := $(addprefix -I,$(SRC_INC_DIRS))
 INCLUDE_FLAGS := $(TEENSY_INC_FLAGS) $(LIBRARY_INC_FLAGS) $(SRC_INC_FLAGS)
 
-# Compiler flags specific to Teensy 4.1
-TEENSY4_FLAGS = -DF_CPU=600000000 -DUSB_CUSTOM -DLAYOUT_US_ENGLISH -D__IMXRT1062__ -DTEENSYDUINO=159 -DARDUINO_TEENSY41 -DARDUINO=10813 -DFIRMWARE
+# Preprocessor definitions specific to Teensy 4.1
+TEENSY4_DEFINES := -DF_CPU=600000000 -DUSB_CUSTOM -DLAYOUT_US_ENGLISH -D__IMXRT1062__ -DTEENSYDUINO=159 -DARDUINO_TEENSY41 -DARDUINO=10813 -DFIRMWARE
 
-# CPU flags to optimize code for the Teensy processor
-CPU_CFLAGS = -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb
+# CPU and ABI flags required during compilation and linking
+ARCH_FLAGS := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb
 
-DEFINES := $(TEENSY4_FLAGS)
+DEFINES := $(TEENSY4_DEFINES)
 
-# Preprocessor flags for both C and C++ files
+# Preprocessor and dependency-generation flags for both C and C++ files
 # -MMD: Generate dependency files for each source file
 # -MP: Add a phony target for each dependency to avoid errors if the dependency is missing
+CPPFLAGS += $(INCLUDE_FLAGS) $(DEFINES)
+DEPFLAGS := -MMD -MP
+
+# Common compiler flags for C and C++ files
 # -ffunction-sections: Place each function in its own section to allow the linker to remove unused functions
 # -fdata-sections: Place each variable in its own section to allow the linker to remove unused variables
 # -O2: Optimize the code for speed
 # --specs=nano.specs: Use newlib nano instead of full newlib to reduce binary size
 # -g3: Generate debug information for GDB. Level 3 includes the most information possible
-CPPFLAGS := $(INCLUDE_FLAGS) $(DEFINES) -MMD -MP -ffunction-sections -fdata-sections -O2 --specs=nano.specs -g3
+COMMON_FLAGS := -ffunction-sections -fdata-sections -O2 --specs=nano.specs -g3
 
 # Compiler flags for C files
-CFLAGS := $(CPU_CFLAGS)
+CFLAGS += $(ARCH_FLAGS) $(COMMON_FLAGS)
 
 # Compiler flags for C++ files
-CXXFLAGS := $(CPU_CFLAGS) -std=gnu++23 \
-			-felide-constructors -fno-exceptions -fpermissive \
-			-Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror \
-			-Wno-volatile
+CXXFLAGS += $(ARCH_FLAGS) $(COMMON_FLAGS) -std=gnu++23 \
+				-felide-constructors -fno-exceptions -fpermissive \
+				-Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror \
+				-Wno-volatile
 
 # Linker flags, including Teensy-specific linker script
 # --gc-sections: Remove unused sections to reduce binary size
@@ -84,7 +88,8 @@ CXXFLAGS := $(CPU_CFLAGS) -std=gnu++23 \
 # -Tteensy4/imxrt1062_t41.ld: Use the Teensy 4.1 linker script
 # --print-memory-usage: Print memory usage after linking
 # -Map=... and --cref: Generate a cross-reference map file
-LINKING_FLAGS = -Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
+LDFLAGS += $(ARCH_FLAGS) --specs=nano.specs \
+	-Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
 
 # Base arm-none-eabi and Teensyduino tool paths
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
@@ -111,7 +116,7 @@ MAKEFLAGS += -j$(nproc)
 
 build:	clangd $(BUILD_DIR)/$(TARGET_ELF)
 $(BUILD_DIR)/$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
-	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LINKING_FLAGS) -o $(BUILD_DIR)/$(TARGET_ELF)
+	@$(COMPILER_CPP) $(LDFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LDLIBS) -o $(BUILD_DIR)/$(TARGET_ELF)
 	@echo [Constructing $(TARGET_HEX)]
 	@$(OBJCOPY) -O ihex -R .eeprom $(BUILD_DIR)/$(TARGET_ELF) $(BUILD_DIR)/$(TARGET_HEX)
 	@chmod +x $(BUILD_DIR)/$(TARGET_HEX)
@@ -123,14 +128,14 @@ $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS): | git_scraper
 $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
-	@$(COMPILER_C) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	@$(COMPILER_C) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 # Build step for compiling C++ source files
 $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
-	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,18 @@
 # Example: make clean build FEATURE_DEFINES="-DPROFILER -DCOMMS_DEBUG"
 FEATURE_DEFINES ?=
 
+BUILD_DIR := build
+TOOLS_DIR := tools
+
 TARGET := firmware
-TARGET_ELF := $(TARGET).elf
-TARGET_HEX := $(TARGET).hex
-TARGET_MAP := $(TARGET).map
-TARGET_DUMP := $(TARGET).dump
+TARGET_ELF := $(BUILD_DIR)/$(TARGET).elf
+TARGET_HEX := $(BUILD_DIR)/$(TARGET).hex
+TARGET_MAP := $(BUILD_DIR)/$(TARGET).map
+TARGET_DUMP := $(BUILD_DIR)$(TARGET).dump
 
-BUILD_DIR := ./build
-
-TOOLS_DIR := ./tools
-
-TEENSY_SRC_DIRS := ./teensy4
-LIBRARY_SRC_DIRS := ./libraries
-SRC_SRC_DIRS := ./src
+TEENSY_SRC_DIRS := teensy4
+LIBRARY_SRC_DIRS := libraries
+SRC_SRC_DIRS := src
 
 TEENSY_SRC := $(shell find $(TEENSY_SRC_DIRS) -name '*.cpp' -or -name '*.c')
 LIBRARY_SRC := $(shell find $(LIBRARY_SRC_DIRS) -name '*.cpp' -or -name '*.c')
@@ -63,8 +62,7 @@ PROJECT_CXXFLAGS := $(COMMON_COMPILE_FLAGS) $(CXX_LANGUAGE_FLAGS) $(CXX_WARNING_
 # --relax: Allow linker to relax some constraints to sometimes generate smaller code
 # -Tteensy4/imxrt1062_t41.ld: Use the Teensy 4.1 linker script
 # -Map=... and --cref: Generate a cross-reference map file
-PROJECT_LDFLAGS := $(ARCH_FLAGS) --specs=nano.specs \
-		-Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
+PROJECT_LDFLAGS := $(ARCH_FLAGS) --specs=nano.specs -Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(TARGET_MAP),--cref
 
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
 TARGET_TRIPLE ?= arm-none-eabi
@@ -85,13 +83,18 @@ GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
 
 
-build:	clangd $(BUILD_DIR)/$(TARGET_ELF)
-$(BUILD_DIR)/$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
-	@$(COMPILER_CPP) $(PROJECT_LDFLAGS) $(LDFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LDLIBS) -o $(BUILD_DIR)/$(TARGET_ELF)
-	@echo [Constructing $(TARGET_HEX)]
-	@$(OBJCOPY) -O ihex -R .eeprom $(BUILD_DIR)/$(TARGET_ELF) $(BUILD_DIR)/$(TARGET_HEX)
-	@chmod +x $(BUILD_DIR)/$(TARGET_HEX)
-	@$(OBJDUMP) -dstz $(BUILD_DIR)/$(TARGET_ELF) > $(BUILD_DIR)/$(TARGET_DUMP)
+build: clangd $(TARGET_ELF)
+
+$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
+	@printf "LINK     %s\n" "$@"
+	@$(COMPILER_CPP) $(PROJECT_LDFLAGS) $(LDFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LDLIBS) -o $@
+
+	@printf "OBJCOPY  %s\n" "$(TARGET_HEX)"
+	@$(OBJCOPY) -O ihex -R .eeprom $@ $(TARGET_HEX)
+	@chmod +x $(TARGET_HEX)
+
+	@printf "OBJDUMP  %s\n" "$(TARGET_DUMP)"
+	@$(OBJDUMP) -dstz $@ > $(TARGET_DUMP)
 
 
 # Ensure git_scraper finishes before compiling any object files
@@ -100,17 +103,16 @@ $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS): | git_scraper
 
 $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
-	@echo [Building $<]
+	@printf "CC       %s\n" "$<"
 	@$(COMPILER_C) $(PROJECT_CPPFLAGS) $(CPPFLAGS) $(PROJECT_CFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 
 $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
-	@echo [Building $<]
+	@printf "CXX      %s\n" "$<"
 	@$(COMPILER_CPP) $(PROJECT_CPPFLAGS) $(CPPFLAGS) $(PROJECT_CXXFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
-
 
 DOC_SCRIPT = $(TOOLS_DIR)/build_docs.sh
 
@@ -140,7 +142,7 @@ git_scraper:
 # Upload firmware to Teensy and start monitoring
 upload: build
 	@echo [Uploading] - If this fails, press the button on the teensy and re-run 'make upload'
-	@tycmd upload $(BUILD_DIR)/$(TARGET_HEX)
+	@tycmd upload $(TARGET_HEX)
 	@sleep 0.4s
 	@bash $(TOOLS_DIR)/monitor.sh
 
@@ -156,7 +158,7 @@ install:
 gdb:
 	@echo [Starting GDB]
 	@bash $(TOOLS_DIR)/prepare_gdb.sh
-	@$(GDB) -x $(TOOLS_DIR)/gdb_commands.txt --args $(BUILD_DIR)/$(TARGET_ELF)
+	@$(GDB) -x $(TOOLS_DIR)/gdb_commands.txt --args $(TARGET_ELF)
 
 
 # monitors currently running firmware on robot
@@ -211,3 +213,4 @@ $(COMPILE_DB): Makefile $(COMPILE_DB_SCRIPT) $(COMPILE_DB_DIR_DEPS)
 	CFLAGS='$(PROJECT_CFLAGS) $(CFLAGS)' \
 	SRC_FILES='$(SRC_SRC) $(LIBRARY_SRC) $(TEENSY_SRC)' \
 	"$(COMPILE_DB_SCRIPT)"
+	@printf "CLANGD   compile_commands.json generated\n"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 # Made by Jack Miller 2024 (Github: guywithhat99)
-# Thanks to Jackson Stepka (Github: Pandabear1125); a lot of code is based off his original makefile 
+# Thanks to Jackson Stepka (Github: Pandabear1125); a lot of code is based off his original makefile
 
 # Detect the current operating system using uname
 UNAME := $(shell uname -s)
 
-# The name of the target executable
-TARGET_EXEC := firmware
+TARGET := firmware
+TARGET_ELF := $(TARGET).elf
+TARGET_HEX := $(TARGET).hex
+TARGET_MAP := $(TARGET).map
+TARGET_DUMP := $(TARGET).dump
 
 # Directory where build outputs will be placed
 BUILD_DIR := ./build
@@ -81,7 +84,7 @@ CXXFLAGS := $(CPU_CFLAGS) -std=gnu++23 \
 # -Tteensy4/imxrt1062_t41.ld: Use the Teensy 4.1 linker script
 # --print-memory-usage: Print memory usage after linking
 # -Map=... and --cref: Generate a cross-reference map file
-LINKING_FLAGS = -Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_EXEC).map,--cref
+LINKING_FLAGS = -Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
 
 # Base arm-none-eabi and Teensyduino tool paths
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
@@ -106,13 +109,13 @@ MAKEFLAGS += -j$(nproc)
 
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
 
-build:	clangd $(BUILD_DIR)/$(TARGET_EXEC)
-$(BUILD_DIR)/$(TARGET_EXEC): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS) 
-	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LINKING_FLAGS) -o $(BUILD_DIR)/$(TARGET_EXEC).elf
-	@echo [Constructing $(TARGET_EXEC).hex]
-	@$(OBJCOPY) -O ihex -R .eeprom $(BUILD_DIR)/$(TARGET_EXEC).elf $(BUILD_DIR)/$(TARGET_EXEC).hex
-	@chmod +x $(BUILD_DIR)/$(TARGET_EXEC).hex
-	@$(OBJDUMP) -dstz $(BUILD_DIR)/$(TARGET_EXEC).elf > $(BUILD_DIR)/$(TARGET_EXEC).dump
+build:	clangd $(BUILD_DIR)/$(TARGET_ELF)
+$(BUILD_DIR)/$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
+	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LINKING_FLAGS) -o $(BUILD_DIR)/$(TARGET_ELF)
+	@echo [Constructing $(TARGET_HEX)]
+	@$(OBJCOPY) -O ihex -R .eeprom $(BUILD_DIR)/$(TARGET_ELF) $(BUILD_DIR)/$(TARGET_HEX)
+	@chmod +x $(BUILD_DIR)/$(TARGET_HEX)
+	@$(OBJDUMP) -dstz $(BUILD_DIR)/$(TARGET_ELF) > $(BUILD_DIR)/$(TARGET_DUMP)
 
 # Ensure git_scraper finishes before compiling any object files
 $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS): | git_scraper
@@ -159,7 +162,7 @@ git_scraper:
 # Upload the firmware to the Teensy device
 upload: build
 	@echo [Uploading] - If this fails, press the button on the teensy and re-run 'make upload'
-	@tycmd upload $(BUILD_DIR)/$(TARGET_EXEC).hex
+	@tycmd upload $(BUILD_DIR)/$(TARGET_HEX)
 	@sleep 0.4s
 	@bash $(TOOLS_DIR)/monitor.sh
 
@@ -175,7 +178,7 @@ install:
 gdb:
 	@echo [Starting GDB]
 	@bash $(TOOLS_DIR)/prepare_gdb.sh
-	@$(GDB) -x $(TOOLS_DIR)/gdb_commands.txt --args $(BUILD_DIR)/$(TARGET_EXEC).elf
+	@$(GDB) -x $(TOOLS_DIR)/gdb_commands.txt --args $(BUILD_DIR)/$(TARGET_ELF)
 
 
 # monitors currently running firmware on robot
@@ -197,7 +200,7 @@ restart:
 	@tycmd reset
 
 
-help: 
+help:
 	@echo "Basic usage: make [target]"
 	@echo "Targets:"
 	@echo "  install:       installs all required dependencies"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # Optional features: PROFILER, COMMS_DEBUG, REF_SYSTEM_DEBUG, CAN_MANAGER_DEBUG
-# Example: make clean build FEATURE_DEFINES="-DPROFILER -DCOMMS_DEBUG"
+# Set them on the line below, e.g. FEATURE_DEFINES ?= -DPROFILER -DCOMMS_DEBUG
+# Rebuild from scratch after editing this line:
+#   make clean
+#   make build
 FEATURE_DEFINES ?=
 
-# Set to 1 to disassemble every object file alongside it, for inspecting the
-# codegen of a single translation unit. Off by default: it adds ~600MB to
-# build/ and a couple of seconds to a clean build.
+# Set to 1 to disassemble every object file alongside it, for inspecting a
+# single translation unit.
 DUMP_OBJS ?= 0
 
 # Build in parallel across all available cores by default.

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ CFLAGS := $(CPU_CFLAGS)
 
 # Compiler flags for C++ files
 CXXFLAGS := $(CPU_CFLAGS) -std=gnu++23 \
-            -felide-constructors -fno-exceptions -fpermissive \
-            -Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror \
+			-felide-constructors -fno-exceptions -fpermissive \
+			-Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror \
 			-Wno-volatile
 
 # Linker flags, including Teensy-specific linker script
@@ -85,12 +85,12 @@ LINKING_FLAGS = -Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-mem
 
 # Set the Arduino path based on the detected operating system
 ifeq ($(UNAME),Darwin)
- ARDUINO_PATH = $(abspath $(HOME)/Library/Arduino15)
- $(info We've detected you are using a Mac! Consult God if this breaks.)
+ARDUINO_PATH = $(abspath $(HOME)/Library/Arduino15)
+$(info We've detected you are using a Mac! Consult God if this breaks.)
 endif
 ifeq ($(UNAME),Linux)
- ARDUINO_PATH = $(abspath $(HOME)/.arduino15)
- $(info We've detected you're on Linux! Nerd.)
+ARDUINO_PATH = $(abspath $(HOME)/.arduino15)
+$(info We've detected you're on Linux! Nerd.)
 endif
 
 # Base arm-none-eabi and Teensyduino tool paths
@@ -125,32 +125,11 @@ build:	clangd $(BUILD_DIR)/$(TARGET_EXEC)
 # It depends on all object files and the 'git_scraper' target to ensure
 # that Git information is up-to-date before linking.
 $(BUILD_DIR)/$(TARGET_EXEC): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS) 
-    # Invoke the C++ compiler as the linker.
-    # - $(COMPILER_CPP): The compiler executable.
-    # - $(CPPFLAGS): Preprocessor and common compiler flags.
-    # - $(CXXFLAGS): C++ compiler flags.
-    # - $(LIBRARY_OBJS), $(TEENSY_OBJS), $(SRC_OBJS): Object files to link.
-    # - $(LINKING_FLAGS): Linker flags, including the linker script.
-    # - '-o $(BUILD_DIR)/$(TARGET_EXEC).elf': Output the ELF executable to the build directory.
 	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LINKING_FLAGS) -o $(BUILD_DIR)/$(TARGET_EXEC).elf
-
-    # Copy the ELF executable to the root directory.
 	@cp $(BUILD_DIR)/$(TARGET_EXEC).elf .
-
-    # Inform the user that the HEX file is being constructed.
 	@echo [Constructing $(TARGET_EXEC).hex]
-
-    # Convert the ELF executable to an Intel HEX format, which is required for uploading to the Teensy board.
-    # - '-O ihex': Specifies the output format as Intel HEX.
-    # - '-R .eeprom': Removes the .eeprom section from the output, as it's not needed for flashing.
-    # - '$(TARGET_EXEC).elf': The input ELF executable.
-    # - '$(TARGET_EXEC).hex': The output HEX file.
 	@$(OBJCOPY) -O ihex -R .eeprom $(TARGET_EXEC).elf $(TARGET_EXEC).hex
-
-    # Ensure the HEX file has execute permissions.
 	@chmod +x $(TARGET_EXEC).hex
-
-    # Disassemble the ELF executable to a .dump file
 	@$(OBJDUMP) -dstz $(BUILD_DIR)/$(TARGET_EXEC).elf > $(BUILD_DIR)/$(TARGET_EXEC).dump
 
 # Ensure git_scraper finishes before compiling any object files
@@ -160,7 +139,6 @@ $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
 	@$(COMPILER_C) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
-    # Disassemble the object file to a .dump file
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 # Build step for compiling C++ source files
@@ -168,7 +146,6 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
 	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
-    # Disassemble the object file to a .dump file
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 
@@ -220,8 +197,6 @@ git_scraper:
 upload: build
 	@echo [Uploading] - If this fails, press the button on the teensy and re-run 'make upload'
 	@tycmd upload $(TARGET_EXEC).hex
-    # Teensy serial isn't immediately available after upload, so we wait a bit
-    # The Teensy waits for 20 + 280 + 20 ms after power up/boot
 	@sleep 0.4s
 	@bash $(TOOLS_DIR)/monitor.sh
 

--- a/Makefile
+++ b/Makefile
@@ -83,16 +83,6 @@ CXXFLAGS := $(CPU_CFLAGS) -std=gnu++23 \
 # -Map=... and --cref: Generate a cross-reference map file
 LINKING_FLAGS = -Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_EXEC).map,--cref
 
-# Set the Arduino path based on the detected operating system
-ifeq ($(UNAME),Darwin)
-ARDUINO_PATH = $(abspath $(HOME)/Library/Arduino15)
-$(info We've detected you are using a Mac! Consult God if this breaks.)
-endif
-ifeq ($(UNAME),Linux)
-ARDUINO_PATH = $(abspath $(HOME)/.arduino15)
-$(info We've detected you're on Linux! Nerd.)
-endif
-
 # Base arm-none-eabi and Teensyduino tool paths
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
 TARGET_TRIPLE ?= arm-none-eabi

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 # Example: make clean build FEATURE_DEFINES="-DPROFILER -DCOMMS_DEBUG"
 FEATURE_DEFINES ?=
 
+# Set to 1 to disassemble every object file alongside it, for inspecting the
+# codegen of a single translation unit. Off by default: it adds ~600MB to
+# build/ and a couple of seconds to a clean build.
+DUMP_OBJS ?= 0
+
 # Build in parallel across all available cores by default.
 # A -j here overrides one given on the command line, so use JOBS to change it:
 # 'make JOBS=1 build' for readable serial output.
@@ -126,14 +131,14 @@ $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	@printf "CC       %s\n" "$<"
 	@$(COMPILER_C) $(PROJECT_CPPFLAGS) $(CPPFLAGS) $(PROJECT_CFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
-	@$(OBJDUMP) -dstz $@ > $@.dump
+	@$(if $(filter-out 0,$(DUMP_OBJS)),$(OBJDUMP) -dstz $@ > $@.dump)
 
 
 $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	@printf "CXX      %s\n" "$<"
 	@$(COMPILER_CPP) $(PROJECT_CPPFLAGS) $(CPPFLAGS) $(PROJECT_CXXFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
-	@$(OBJDUMP) -dstz $@ > $@.dump
+	@$(if $(filter-out 0,$(DUMP_OBJS)),$(OBJDUMP) -dstz $@ > $@.dump)
 
 DOC_SCRIPT = $(TOOLS_DIR)/build_docs.sh
 
@@ -221,6 +226,10 @@ help:
 	@echo "  clean:         removes all build artifacts and generated files"
 	@echo "  clangd:        generates compile_commands.json for clangd"
 	@echo "  docs:          generates documentation of our src/ code using Doxygen"
+	@echo ""
+	@echo "Variables:"
+	@echo "  JOBS=N         parallel jobs (defaults to core count)"
+	@echo "  DUMP_OBJS=1    also disassemble each object file"
 
 
 # Generate compile_commands.json from the Makefile's flags and source lists.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Optional features: PROFILER, COMMS_DEBUG, REF_SYSTEM_DEBUG, CAN_MANAGER_DEBUG
+# Example: make clean build FEATURE_DEFINES="-DPROFILER -DCOMMS_DEBUG"
+FEATURE_DEFINES ?=
+
 TARGET := firmware
 TARGET_ELF := $(TARGET).elf
 TARGET_HEX := $(TARGET).hex
@@ -37,33 +41,30 @@ INCLUDE_FLAGS := $(TEENSY_INC_FLAGS) $(LIBRARY_INC_FLAGS) $(SRC_INC_FLAGS)
 # CPU and ABI flags required during compilation and linking
 ARCH_FLAGS := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb
 
-# Preprocessor definitions specific to Teensy 4.1
-TEENSY41_DEFINES := -DF_CPU=600000000 -DUSB_CUSTOM -DLAYOUT_US_ENGLISH -D__IMXRT1062__ -DTEENSYDUINO=159 -DARDUINO_TEENSY41 -DARDUINO=10813 -DFIRMWARE
+BOARD_DEFINES := -DF_CPU=600000000 -D__IMXRT1062__ -DTEENSYDUINO=159 -DARDUINO_TEENSY41 -DARDUINO=10813
+USB_DEFINES := -DUSB_CUSTOM -DLAYOUT_US_ENGLISH
+PROJECT_DEFINES := $(BOARD_DEFINES) $(USB_DEFINES) -DFIRMWARE $(FEATURE_DEFINES)
 
 # -MMD: Generate dependency files for each source file
 # -MP: Add a phony target for each dependency to avoid errors if the dependency is missing
 DEPFLAGS := -MMD -MP
 
-# -ffunction-sections: Place each function in its own section to allow the linker to remove unused functions
-# -fdata-sections: Place each variable in its own section to allow the linker to remove unused variables
-# --specs=nano.specs: Use newlib nano instead of full newlib to reduce binary size
-COMMON_FLAGS := -ffunction-sections -fdata-sections -O2 --specs=nano.specs -g3
+# Place each function and variable in its own section so the linker can remove unused code and data
+SECTION_FLAGS := -ffunction-sections -fdata-sections
+COMMON_COMPILE_FLAGS := $(ARCH_FLAGS) $(SECTION_FLAGS) -O2 -g3 --specs=nano.specs
+CXX_LANGUAGE_FLAGS := -std=gnu++23 -felide-constructors -fno-exceptions -fpermissive
+CXX_WARNING_FLAGS := -Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror -Wno-volatile
 
-CPPFLAGS += $(INCLUDE_FLAGS) $(TEENSY41_DEFINES)
-
-CFLAGS += $(ARCH_FLAGS) $(COMMON_FLAGS)
-
-CXXFLAGS += $(ARCH_FLAGS) $(COMMON_FLAGS) -std=gnu++23 \
-				-felide-constructors -fno-exceptions -fpermissive \
-				-Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror \
-				-Wno-volatile
+PROJECT_CPPFLAGS := $(INCLUDE_FLAGS) $(PROJECT_DEFINES)
+PROJECT_CFLAGS := $(COMMON_COMPILE_FLAGS)
+PROJECT_CXXFLAGS := $(COMMON_COMPILE_FLAGS) $(CXX_LANGUAGE_FLAGS) $(CXX_WARNING_FLAGS)
 
 # --gc-sections: Remove unused sections to reduce binary size
 # --relax: Allow linker to relax some constraints to sometimes generate smaller code
 # -Tteensy4/imxrt1062_t41.ld: Use the Teensy 4.1 linker script
 # -Map=... and --cref: Generate a cross-reference map file
-LDFLAGS += $(ARCH_FLAGS) --specs=nano.specs \
-	-Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
+PROJECT_LDFLAGS := $(ARCH_FLAGS) --specs=nano.specs \
+		-Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
 
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
 TARGET_TRIPLE ?= arm-none-eabi
@@ -86,7 +87,7 @@ GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 
 build:	clangd $(BUILD_DIR)/$(TARGET_ELF)
 $(BUILD_DIR)/$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
-	@$(COMPILER_CPP) $(LDFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LDLIBS) -o $(BUILD_DIR)/$(TARGET_ELF)
+	@$(COMPILER_CPP) $(PROJECT_LDFLAGS) $(LDFLAGS) $(LIBRARY_OBJS) $(TEENSY_OBJS) $(SRC_OBJS) $(LDLIBS) -o $(BUILD_DIR)/$(TARGET_ELF)
 	@echo [Constructing $(TARGET_HEX)]
 	@$(OBJCOPY) -O ihex -R .eeprom $(BUILD_DIR)/$(TARGET_ELF) $(BUILD_DIR)/$(TARGET_HEX)
 	@chmod +x $(BUILD_DIR)/$(TARGET_HEX)
@@ -100,14 +101,14 @@ $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS): | git_scraper
 $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
-	@$(COMPILER_C) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
+	@$(COMPILER_C) $(PROJECT_CPPFLAGS) $(CPPFLAGS) $(PROJECT_CFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 
 $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
-	@$(COMPILER_CPP) $(CPPFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
+	@$(COMPILER_CPP) $(PROJECT_CPPFLAGS) $(CPPFLAGS) $(PROJECT_CXXFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 
@@ -205,8 +206,8 @@ $(COMPILE_DB): Makefile $(COMPILE_DB_SCRIPT) $(COMPILE_DB_DIR_DEPS)
 	COMPILER_CPP="$(COMPILER_CPP)" \
 	COMPILER_C="$(COMPILER_C)" \
 	TARGET_TRIPLE="$(TARGET_TRIPLE)" \
-	CPPFLAGS='$(CPPFLAGS)' \
-	CXXFLAGS='$(CXXFLAGS)' \
-	CFLAGS='$(CFLAGS)' \
+	CPPFLAGS='$(PROJECT_CPPFLAGS) $(CPPFLAGS)' \
+	CXXFLAGS='$(PROJECT_CXXFLAGS) $(CXXFLAGS)' \
+	CFLAGS='$(PROJECT_CFLAGS) $(CFLAGS)' \
 	SRC_FILES='$(SRC_SRC) $(LIBRARY_SRC) $(TEENSY_SRC)' \
 	"$(COMPILE_DB_SCRIPT)"

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,7 @@ GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 # Utilize all available CPU cores for parallel build
 MAKEFLAGS += -j$(nproc)
 
-# Phony target to force a build every time
-.PHONY: build
-
+.PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
 
 build:	clangd $(BUILD_DIR)/$(TARGET_EXEC)
 $(BUILD_DIR)/$(TARGET_EXEC): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS) 
@@ -145,32 +143,16 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 
 
 DOC_SCRIPT = $(TOOLS_DIR)/build_docs.sh
-# Phony target to generate documentation using Doxygen
-.PHONY: docs
 
 docs: build
 	@chmod +x $(DOC_SCRIPT)
 	@$(DOC_SCRIPT)
 
-# Phony target to prevent conflicts with files named 'clean' and force a rebuild every time
-.PHONY: clean
 
 # Clean the build directory and remove generated executables
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -f compile_commands.json
-
-# Clean only the source object files
-clean_src:
-	rm -r $(BUILD_DIR)/src
-
-# Clean only the library object files
-clean_libs:
-	rm -r $(BUILD_DIR)/libraries
-
-# Clean only the Teensy object files
-clean_teensy4:
-	rm -r $(BUILD_DIR)/teensy4
 
 # Include the dependency files to manage header file dependencies
 # The '-' suppresses errors if the files are missing (which they will be on the first run)
@@ -178,8 +160,6 @@ clean_teensy4:
 -include $(LIBRARY_DEPS)
 -include $(SRC_DEPS)
 
-# Build, run, and clean up the git scraper tool to store current Git info in a header file
-.PHONY: git_scraper
 git_scraper:
 	@g++ -std=gnu++17 $(GIT_SCRAPER) -o $(TOOLS_DIR)/git_scraper
 	@$(TOOLS_DIR)/git_scraper
@@ -238,9 +218,6 @@ help:
 	@echo "  kill:          stops any running firmware"
 	@echo "  restart:       restarts any running firmware"
 	@echo "  clean:         removes all build artifacts and generated files"
-	@echo "  clean_src:     removes only the source object files"
-	@echo "  clean_libs:    removes only the library object files"
-	@echo "  clean_teensy4: removes only the Teensy object files"
 	@echo "  clangd:        generates compile_commands.json for clangd"
 	@echo "  docs:          generates documentation of our src/ code using Doxygen"
 
@@ -250,7 +227,6 @@ COMPILE_DB = compile_commands.json
 COMPILE_DB_SCRIPT = $(TOOLS_DIR)/generate_compile_commands.sh
 COMPILE_DB_DIR_DEPS = $(SRC_INC_DIRS) $(LIBRARY_INC_DIRS) $(TEENSY_INC_DIRS)
 
-.PHONY: clangd
 clangd: $(COMPILE_DB)
 
 $(COMPILE_DB): Makefile $(COMPILE_DB_SCRIPT) $(COMPILE_DB_DIR_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 # Example: make clean build FEATURE_DEFINES="-DPROFILER -DCOMMS_DEBUG"
 FEATURE_DEFINES ?=
 
+# Build in parallel across all available cores by default.
+# A -j here overrides one given on the command line, so use JOBS to change it:
+# 'make JOBS=1 build' for readable serial output.
+JOBS ?= $(shell sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 1)
+MAKEFLAGS += -j$(JOBS)
+
 BUILD_DIR := build
 TOOLS_DIR := tools
 
@@ -84,10 +90,14 @@ GIT_SCRAPER_SRC = $(TOOLS_DIR)/git_scraper.cpp
 GIT_SCRAPER_BIN = $(BUILD_DIR)/git_scraper
 
 
-.PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
+.PHONY: build dump docs clean upload install gdb monitor kill restart help clangd git_scraper
 
 
-build: $(TARGET_HEX) $(TARGET_DUMP)
+build: $(TARGET_HEX)
+
+
+dump: $(TARGET_DUMP)
+
 
 $(TARGET_ELF): $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
 	@printf "LINK     %s\n" "$@"
@@ -199,6 +209,7 @@ help:
 	@echo "Targets:"
 	@echo "  install:       installs all required dependencies"
 	@echo "  build:         compiles the source code and links with libraries"
+	@echo "  dump:          generates a disassembly of the built firmware"
 	@echo "  upload:        builds the source and uploads it to the Teensy"
 	@echo "  gdb:           starts GDB and attaches to the firmware running on a connected Teensy"
 	@echo "  monitor:       monitors any actively running firmware and displays serial output"

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ SRC_DEPS := $(SRC_OBJS:.o=.d)
 
 TEENSY_INC_DIRS := $(shell find $(TEENSY_SRC_DIRS) -type d)
 LIBRARY_INC_DIRS := $(LIBRARY_SRC_DIRS) \
-	$(wildcard $(LIBRARY_SRC_DIRS)/*/) \
-	$(wildcard $(LIBRARY_SRC_DIRS)/*/src/) \
-	$(wildcard $(LIBRARY_SRC_DIRS)/*/utility/)
+	$(patsubst %/,%,$(wildcard \
+		$(LIBRARY_SRC_DIRS)/*/ \
+		$(LIBRARY_SRC_DIRS)/*/src/ \
+		$(LIBRARY_SRC_DIRS)/*/utility/))
 SRC_INC_DIRS := $(SRC_SRC_DIRS)
 
 # -isystem on Teensy and Library files to suppress warnings

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
 
 
-build: clangd $(TARGET_ELF)
+build: $(TARGET_ELF)
 
 $(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
 	@printf "LINK     %s\n" "$@"

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,10 @@ DEPFLAGS := -MMD -MP
 
 # Place each function and variable in its own section so the linker can remove unused code and data
 SECTION_FLAGS := -ffunction-sections -fdata-sections
-COMMON_COMPILE_FLAGS := $(ARCH_FLAGS) $(SECTION_FLAGS) -O2 -g3 --specs=nano.specs
+# -g2: full line tables for addr2line/GDB. -g3 additionally emits macro
+# definitions, which cost ~7x in object size and are not needed by the
+# addr2line crash-report workflow in teensy4/CrashReport.cpp.
+COMMON_COMPILE_FLAGS := $(ARCH_FLAGS) $(SECTION_FLAGS) -O2 -g2 --specs=nano.specs
 CXX_LANGUAGE_FLAGS := -std=gnu++23 -felide-constructors -fno-exceptions -fpermissive
 CXX_WARNING_FLAGS := -Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror -Wno-volatile
 

--- a/Makefile
+++ b/Makefile
@@ -1,101 +1,73 @@
-# Made by Jack Miller 2024 (Github: guywithhat99)
-# Thanks to Jackson Stepka (Github: Pandabear1125); a lot of code is based off his original makefile
-
-# Detect the current operating system using uname
-UNAME := $(shell uname -s)
-
 TARGET := firmware
 TARGET_ELF := $(TARGET).elf
 TARGET_HEX := $(TARGET).hex
 TARGET_MAP := $(TARGET).map
 TARGET_DUMP := $(TARGET).dump
 
-# Directory where build outputs will be placed
 BUILD_DIR := ./build
 
-# Tools directory
 TOOLS_DIR := ./tools
 
-# Source directories
 TEENSY_SRC_DIRS := ./teensy4
 LIBRARY_SRC_DIRS := ./libraries
 SRC_SRC_DIRS := ./src
 
-# Find all C, C++, and assembly source files in the specified directories
-# Note: Single quotes are used to prevent the shell from expanding '*'
 TEENSY_SRC := $(shell find $(TEENSY_SRC_DIRS) -name '*.cpp' -or -name '*.c')
 LIBRARY_SRC := $(shell find $(LIBRARY_SRC_DIRS) -name '*.cpp' -or -name '*.c')
 SRC_SRC := $(shell find $(SRC_SRC_DIRS) -name '*.cpp' -or -name '*.c')
 
-# Generate object file paths by prepending BUILD_DIR and appending .o to source files
-# Example: ./your_dir/hello.cpp turns into ./build/./your_dir/hello.cpp.o
 TEENSY_OBJS := $(TEENSY_SRC:%=$(BUILD_DIR)/%.o)
 LIBRARY_OBJS := $(LIBRARY_SRC:%=$(BUILD_DIR)/%.o)
 SRC_OBJS :=  $(SRC_SRC:%=$(BUILD_DIR)/%.o)
 
-# Generate dependency file paths by replacing .o with .d in object file paths
-# Example: ./build/hello.cpp.o turns into ./build/hello.cpp.d
 TEENSY_DEPS := $(TEENSY_OBJS:.o=.d)
 LIBRARY_DEPS := $(LIBRARY_OBJS:.o=.d)
 SRC_DEPS := $(SRC_OBJS:.o=.d)
 
-# Find all include directories for GCC to locate header files
 TEENSY_INC_DIRS := $(shell find $(TEENSY_SRC_DIRS) -type d)
 LIBRARY_INC_DIRS := $(shell find $(LIBRARY_SRC_DIRS) -maxdepth 2 -type d)
 SRC_INC_DIRS := $(shell find $(SRC_SRC_DIRS) -type d)
 
-# Generate compiler include flags from include directories
 # -isystem on Teensy and Library files to suppress warnings
 TEENSY_INC_FLAGS := $(addprefix -isystem,$(TEENSY_INC_DIRS))
 LIBRARY_INC_FLAGS := $(addprefix -isystem,$(LIBRARY_INC_DIRS))
 SRC_INC_FLAGS := $(addprefix -I,$(SRC_INC_DIRS))
 INCLUDE_FLAGS := $(TEENSY_INC_FLAGS) $(LIBRARY_INC_FLAGS) $(SRC_INC_FLAGS)
 
-# Preprocessor definitions specific to Teensy 4.1
-TEENSY4_DEFINES := -DF_CPU=600000000 -DUSB_CUSTOM -DLAYOUT_US_ENGLISH -D__IMXRT1062__ -DTEENSYDUINO=159 -DARDUINO_TEENSY41 -DARDUINO=10813 -DFIRMWARE
-
 # CPU and ABI flags required during compilation and linking
 ARCH_FLAGS := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb
 
-DEFINES := $(TEENSY4_DEFINES)
+# Preprocessor definitions specific to Teensy 4.1
+TEENSY41_DEFINES := -DF_CPU=600000000 -DUSB_CUSTOM -DLAYOUT_US_ENGLISH -D__IMXRT1062__ -DTEENSYDUINO=159 -DARDUINO_TEENSY41 -DARDUINO=10813 -DFIRMWARE
 
-# Preprocessor and dependency-generation flags for both C and C++ files
 # -MMD: Generate dependency files for each source file
 # -MP: Add a phony target for each dependency to avoid errors if the dependency is missing
-CPPFLAGS += $(INCLUDE_FLAGS) $(DEFINES)
 DEPFLAGS := -MMD -MP
 
-# Common compiler flags for C and C++ files
 # -ffunction-sections: Place each function in its own section to allow the linker to remove unused functions
 # -fdata-sections: Place each variable in its own section to allow the linker to remove unused variables
-# -O2: Optimize the code for speed
 # --specs=nano.specs: Use newlib nano instead of full newlib to reduce binary size
-# -g3: Generate debug information for GDB. Level 3 includes the most information possible
 COMMON_FLAGS := -ffunction-sections -fdata-sections -O2 --specs=nano.specs -g3
 
-# Compiler flags for C files
+CPPFLAGS += $(INCLUDE_FLAGS) $(TEENSY41_DEFINES)
+
 CFLAGS += $(ARCH_FLAGS) $(COMMON_FLAGS)
 
-# Compiler flags for C++ files
 CXXFLAGS += $(ARCH_FLAGS) $(COMMON_FLAGS) -std=gnu++23 \
 				-felide-constructors -fno-exceptions -fpermissive \
 				-Wno-error=narrowing -Wno-trigraphs -Wno-comment -Wall -Werror \
 				-Wno-volatile
 
-# Linker flags, including Teensy-specific linker script
 # --gc-sections: Remove unused sections to reduce binary size
 # --relax: Allow linker to relax some constraints to sometimes generate smaller code
 # -Tteensy4/imxrt1062_t41.ld: Use the Teensy 4.1 linker script
-# --print-memory-usage: Print memory usage after linking
 # -Map=... and --cref: Generate a cross-reference map file
 LDFLAGS += $(ARCH_FLAGS) --specs=nano.specs \
 	-Wl,--gc-sections,--relax,-Tteensy4/imxrt1062_t41.ld,--print-memory-usage,-Map=$(BUILD_DIR)/$(TARGET_MAP),--cref
 
-# Base arm-none-eabi and Teensyduino tool paths
 COMPILER_TOOLS_PATH = $(TOOLS_DIR)/compiler/arm-gnu-toolchain/bin
 TARGET_TRIPLE ?= arm-none-eabi
 
-# arm-none-eabi tools
 COMPILER_CPP	= $(COMPILER_TOOLS_PATH)/arm-none-eabi-g++
 COMPILER_C		= $(COMPILER_TOOLS_PATH)/arm-none-eabi-gcc
 AR				= $(COMPILER_TOOLS_PATH)/arm-none-eabi-ar
@@ -106,10 +78,11 @@ READELF			= $(COMPILER_TOOLS_PATH)/arm-none-eabi-readelf
 ADDR2LINE		= $(COMPILER_TOOLS_PATH)/arm-none-eabi-addr2line
 SIZE			= $(COMPILER_TOOLS_PATH)/arm-none-eabi-size
 
-# Path to the Git scraper tool source file
 GIT_SCRAPER = $(TOOLS_DIR)/git_scraper.cpp
 
+
 .PHONY: build docs clean upload install gdb monitor kill restart help clangd git_scraper
+
 
 build:	clangd $(BUILD_DIR)/$(TARGET_ELF)
 $(BUILD_DIR)/$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS)
@@ -119,16 +92,18 @@ $(BUILD_DIR)/$(TARGET_ELF): git_scraper $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJ
 	@chmod +x $(BUILD_DIR)/$(TARGET_HEX)
 	@$(OBJDUMP) -dstz $(BUILD_DIR)/$(TARGET_ELF) > $(BUILD_DIR)/$(TARGET_DUMP)
 
+
 # Ensure git_scraper finishes before compiling any object files
 $(SRC_OBJS) $(LIBRARY_OBJS) $(TEENSY_OBJS): | git_scraper
-# Build step for compiling C source files
+
+
 $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
 	@$(COMPILER_C) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
-# Build step for compiling C++ source files
+
 $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	@echo [Building $<]
@@ -136,15 +111,14 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 	@$(OBJDUMP) -dstz $@ > $@.dump
 
 
-
 DOC_SCRIPT = $(TOOLS_DIR)/build_docs.sh
+
 
 docs: build
 	@chmod +x $(DOC_SCRIPT)
 	@$(DOC_SCRIPT)
 
 
-# Clean the build directory and remove generated executables
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -f compile_commands.json
@@ -155,13 +129,14 @@ clean:
 -include $(LIBRARY_DEPS)
 -include $(SRC_DEPS)
 
+
 git_scraper:
 	@g++ -std=gnu++17 $(GIT_SCRAPER) -o $(TOOLS_DIR)/git_scraper
 	@$(TOOLS_DIR)/git_scraper
 	@rm $(TOOLS_DIR)/git_scraper
 
 
-# Upload the firmware to the Teensy device
+# Upload firmware to Teensy and start monitoring
 upload: build
 	@echo [Uploading] - If this fails, press the button on the teensy and re-run 'make upload'
 	@tycmd upload $(BUILD_DIR)/$(TARGET_HEX)
@@ -169,7 +144,7 @@ upload: build
 	@bash $(TOOLS_DIR)/monitor.sh
 
 
-# Install required tools for building and uploading firmware
+# Install requirements for building and uploading firmware
 install:
 	@bash $(TOOLS_DIR)/install_tytools.sh
 	@bash $(TOOLS_DIR)/install_compiler.sh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ LIBRARY_DEPS := $(LIBRARY_OBJS:.o=.d)
 SRC_DEPS := $(SRC_OBJS:.o=.d)
 
 TEENSY_INC_DIRS := $(shell find $(TEENSY_SRC_DIRS) -type d)
-LIBRARY_INC_DIRS := $(shell find $(LIBRARY_SRC_DIRS) -maxdepth 2 -type d)
+LIBRARY_INC_DIRS := $(LIBRARY_SRC_DIRS) \
+	$(wildcard $(LIBRARY_SRC_DIRS)/*/) \
+	$(wildcard $(LIBRARY_SRC_DIRS)/*/src/) \
+	$(wildcard $(LIBRARY_SRC_DIRS)/*/utility/)
 SRC_INC_DIRS := $(SRC_SRC_DIRS)
 
 # -isystem on Teensy and Library files to suppress warnings

--- a/src/comms/config_data/controller.hpp
+++ b/src/comms/config_data/controller.hpp
@@ -5,7 +5,7 @@
 #include "comms/data/comms_data.hpp" // for CommsData, TypeLabel, to_string
 #include "comms/config_data/motor.hpp" // for Motor
 #include "state.hpp" // for StateName
-#include "safety.hpp" // for assert_or_safety_mode
+#include "utils/safety.hpp" // for assert_or_safety_mode
 
 /// These values are arbitrary limits for the size of the arrays in the Controller struct. 
 // They should be large enough to accommodate any reasonable number of motors, states, or sub controllers per controller configuration.

--- a/src/comms/config_data/estimator.hpp
+++ b/src/comms/config_data/estimator.hpp
@@ -5,7 +5,7 @@
 #include "state.hpp"      // for StateName
 #include "motor.hpp"      // for MotorName
 #include "sensor.hpp"     // for SensorName
-#include "safety.hpp" // for assert_or_safety_mode
+#include "utils/safety.hpp" // for assert_or_safety_mode
 
 /// These values are arbitrary limits for the size of the arrays in the Estimator struct. 
 // They should be large enough to accommodate any reasonable number of states, motors, or sensors used by an estimator configuration.

--- a/src/comms/data/hive_data.cpp
+++ b/src/comms/data/hive_data.cpp
@@ -1,6 +1,6 @@
 #include "hive_data.hpp"
 #include "comms_data.hpp"
-#include "config_data/sensor.hpp"
+#include "comms/config_data/sensor.hpp"
 
 #include "comms/comms_layer.hpp"            // for CommsLayer
 

--- a/src/comms/data/packet_payload.cpp
+++ b/src/comms/data/packet_payload.cpp
@@ -1,5 +1,5 @@
 #include "packet_payload.hpp"
-#include "safety.hpp"
+#include "utils/safety.hpp"
 
 #include <algorithm>                        // for min
 #include "comms/comms_layer.hpp"            // for CommsLayer

--- a/src/comms/data/sendable.hpp
+++ b/src/comms/data/sendable.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <type_traits>                          // for is_base_of, is_copy_constructible
-#include "comms_layer.hpp"                      // for CommsLayer
+#include "comms/comms_layer.hpp"                // for CommsLayer
 
 namespace Comms {
 

--- a/src/comms/ethernet_comms.hpp
+++ b/src/comms/ethernet_comms.hpp
@@ -8,10 +8,6 @@ namespace qn = qindesign::network;
 #include "utils/timing.hpp"				// for Timer
 #include "comms/ethernet_packet.hpp"	// for EthernetPacket
 
-// DEBUG define for displaying all comms errors/status updates
-// This is very noisy on start up
-// #define COMMS_DEBUG
-
 namespace Comms {
 
 /// @brief Ethernet Communications. This handles all comms between the Jetson and the Teensy via Ethernet

--- a/src/controls/controller.cpp
+++ b/src/controls/controller.cpp
@@ -1,5 +1,5 @@
 #include "controller.hpp"
-#include "motor.hpp"
+#include "sensors/can/motor.hpp"
 #include "sensors/RefSystem.hpp"
 
 namespace {

--- a/src/controls/controller.hpp
+++ b/src/controls/controller.hpp
@@ -2,8 +2,8 @@
 
 #include "estimator.hpp"
 #include "filters/pid_filter.hpp"
-#include "motor.hpp"
-#include "safety.hpp"
+#include "sensors/can/motor.hpp"
+#include "utils/safety.hpp"
 #include "utils/timing.hpp"
 #include "sensors/can/can_manager.hpp"
 #include "robot_state_map.hpp"

--- a/src/controls/estimator.cpp
+++ b/src/controls/estimator.cpp
@@ -2,7 +2,7 @@
 #include <limits>
 
 #include "estimator.hpp"
-#include "ICM20649.hpp"
+#include "sensors/ICM20649.hpp"
 #include "utils/vector_math.hpp"
 #include "utils/wrapping.hpp"
 #include "sensors/RefSystem.hpp"

--- a/src/controls/estimator.hpp
+++ b/src/controls/estimator.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "estimator.hpp"
+#include "comms/config_data/estimator.hpp"
 #include "robot_state_map.hpp"
-#include "safety.hpp"
+#include "utils/safety.hpp"
 #include "sensors/can/can_manager.hpp"
 #include "state.hpp"
 #include "utils/timing.hpp"

--- a/src/hello_robot.hpp
+++ b/src/hello_robot.hpp
@@ -2,16 +2,16 @@
 #include <Arduino.h>
 #include <optional>
 
-#include "can_manager.hpp"
+#include "sensors/can/can_manager.hpp"
 #include "comms/comms_layer.hpp"
 #include "controls/reference_governor.hpp"
 #include "controls/state.hpp"
 #include "git_info.h"
 
-#include "robot_state_map.hpp"
-#include "safety.hpp"
+#include "controls/robot_state_map.hpp"
+#include "utils/safety.hpp"
 #include "sensors/buff_encoder.hpp"
-#include "state.hpp"
+#include "comms/config_data/state.hpp"
 #include "utils/boot_splash.hpp"
 #include "utils/profiler.hpp"
 
@@ -25,7 +25,7 @@
 #include "sensors/StereoCamTrigger.hpp"
 #include "utils/profiler.hpp"
 
-#include "sensor_manager.hpp"
+#include "sensors/sensor_manager.hpp"
 #include <TeensyDebug.h>
 #include <wiring.h>
 

--- a/src/sensors/ICM20649.cpp
+++ b/src/sensors/ICM20649.cpp
@@ -1,5 +1,5 @@
 #include "ICM20649.hpp"
-#include "safety.hpp"
+#include "utils/safety.hpp"
 #include "comms/data/sendable.hpp"
 
 // initialize ICM

--- a/src/sensors/RefSystem.cpp
+++ b/src/sensors/RefSystem.cpp
@@ -3,9 +3,6 @@
 #include "comms/data/sendable.hpp"
 RefSystem ref; // Global instance
 
-// Uncomment to enable debug prints
-// #define REF_SYSTEM_DEBUG
-
 uint8_t generateCRC8(const uint8_t *data, uint32_t len) {
     uint8_t CRC8 = 0xFF;
     while (len-- > 0) {

--- a/src/sensors/StereoCamTrigger.cpp
+++ b/src/sensors/StereoCamTrigger.cpp
@@ -1,6 +1,6 @@
 #include "StereoCamTrigger.hpp"
 #include "comms/data/sendable.hpp"
-#include "transmitter_utils.hpp"
+#include "sensors/transmitter/transmitter_utils.hpp"
 #include <core_pins.h>
 
 std::unique_ptr<RobotStateMap>* StereoCamTrigger::estimated_state_map_interrupt_safe = nullptr;

--- a/src/sensors/StereoCamTrigger.hpp
+++ b/src/sensors/StereoCamTrigger.hpp
@@ -4,7 +4,7 @@
 #include <avr/interrupt.h>
 #include "sensors/sensor.hpp"
 #include "comms/data/stereo_cam_trigger_data.hpp"
-#include "robot_state_map.hpp"
+#include "controls/robot_state_map.hpp"
 #include <memory>
 
 

--- a/src/sensors/can/can_manager.cpp
+++ b/src/sensors/can/can_manager.cpp
@@ -1,7 +1,7 @@
 #include "can_manager.hpp"
 
 // driver includes are here not in header since they're only needed in the implementation
-#include "safety.hpp"
+#include "utils/safety.hpp"
 #include "sensors/can/C610.hpp"
 #include "sensors/can/C620.hpp"
 #include "sensors/can/MG8016EI6.hpp"

--- a/src/sensors/can/can_manager.hpp
+++ b/src/sensors/can/can_manager.hpp
@@ -3,9 +3,6 @@
 #include "motor.hpp"
 #include <map>
 #include <memory>
-/// @brief Debug flag to enable verbose logging. This can get quite noisy so it is off by default. Critical errors are still printed regardless of flag
-// #define CAN_MANAGER_DEBUG
-
 /// @brief The maximum number of motors that can be connected to a single bus
 constexpr uint32_t CAN_MAX_MOTORS_PER_BUS = 8u;
 

--- a/src/sensors/sensor.hpp
+++ b/src/sensors/sensor.hpp
@@ -2,7 +2,7 @@
 #include <memory>
 
 #include "comms/config_data/sensor.hpp"
-#include "robot_state_map.hpp"
+#include "controls/robot_state_map.hpp"
 
 
 /// @brief Abstract class representing a sensor. All sensors should inherit from this class.

--- a/src/sensors/transmitter/ET16S.cpp
+++ b/src/sensors/transmitter/ET16S.cpp
@@ -1,7 +1,7 @@
 #include "ET16S.hpp"
 #include "sensors/RefSystem.hpp"
 #include "comms/data/sendable.hpp"
-#include "state.hpp"
+#include "comms/config_data/state.hpp"
 
 ET16S::ET16S(const Cfg::ET16S& config) : config(config) { }
 

--- a/src/utils/profiler.hpp
+++ b/src/utils/profiler.hpp
@@ -1,9 +1,6 @@
 #ifndef PROFILER_H
 #define PROFILER_H
 
-// Use this flag to toggle profiling globally.
-//#define PROFILER
-
 #include <Arduino.h>
 
 #define PROF_MAX_SECTIONS 4   // max number of active profiling sections

--- a/tools/generate_compile_commands.sh
+++ b/tools/generate_compile_commands.sh
@@ -39,8 +39,6 @@ get_system_includes() {
 : "${CFLAGS:?CFLAGS is required}"
 : "${SRC_FILES:?SRC_FILES is required}"
 
-echo "[Generating compile_commands.json]"
-
 if [[ ! -x "$COMPILER_CPP" ]]; then
     echo "Error: C++ compiler not found at $COMPILER_CPP" >&2
     exit 1
@@ -138,5 +136,3 @@ printf '\n]\n' >&3
 exec 3>&-
 mv "$tmp_db" compile_commands.json
 trap - EXIT
-
-echo "[compile_commands.json generated with $entry_count entries]"

--- a/tools/git_scraper.cpp
+++ b/tools/git_scraper.cpp
@@ -59,35 +59,53 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// Now we construct the header file
-	std::ofstream git_info_header(path_to_header + header_name);
-	if (!git_info_header.is_open()) {
-		std::cout << "Failed to open '" << path_to_header + header_name << "'" << std::endl;
-		return -1;
-	}
+	// Now we construct the header file in memory
+	std::ostringstream header_contents;
 
 	// Add a message saying this file was auto-generated
-	git_info_header << "// THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT" << "\n\n";
+	header_contents << "// THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT" << "\n\n";
 
 	// Add a header guard
-	git_info_header << "#ifndef " << header_guard << "\n";
-	git_info_header << "#define " << header_guard << "\n\n";
+	header_contents << "#ifndef " << header_guard << "\n";
+	header_contents << "#define " << header_guard << "\n\n";
 
 	// Add the branch name
-	git_info_header << "#define " << branch_define_name << " \"" << branch << "\"\n";
+	header_contents << "#define " << branch_define_name << " \"" << branch << "\"\n";
 	// Add the commit hash
-	git_info_header << "#define " << commit_define_name << " \"" << commit_hash << "\"\n";
+	header_contents << "#define " << commit_define_name << " \"" << commit_hash << "\"\n";
 	// Add the commit message
-	git_info_header << "#define " << commit_msg_define_name << " \"" << commit_msg << "\"\n\n";
+	header_contents << "#define " << commit_msg_define_name << " \"" << commit_msg << "\"\n\n";
 
 	// Finish the header guard
-	git_info_header << "#endif // " << header_guard;
+	header_contents << "#endif // " << header_guard;
 
 	// Clean up and remove the temp text file
 	git_info_txt.close();
-	git_info_header.close();
-
 	std::filesystem::remove(temp_txt_name);
+
+	// Only rewrite the header if it would actually change. Rewriting it
+	// unconditionally bumps its mtime every build, which forces make to
+	// recompile every translation unit that includes it.
+	const std::string header_path = path_to_header + header_name;
+	std::ifstream existing_header(header_path);
+	if (existing_header.is_open()) {
+		std::stringstream existing_contents;
+		existing_contents << existing_header.rdbuf();
+		existing_header.close();
+
+		if (existing_contents.str() == header_contents.str()) {
+			return 0;
+		}
+	}
+
+	std::ofstream git_info_header(header_path);
+	if (!git_info_header.is_open()) {
+		std::cout << "Failed to open '" << header_path << "'" << std::endl;
+		return -1;
+	}
+
+	git_info_header << header_contents.str();
+	git_info_header.close();
 
 	return 0;
 }


### PR DESCRIPTION
Rework of the Makefile:
- Parallel builds actually work now. `-j$(nproc)` was a no-op on macOS since `nproc` doesn't exist there. `make JOBS=1` if you want a serial output while building.
- `git_info.h` is only rewritten when its contents change. It was being rebuilt every `make`.
- `git_scraper` is compiled once into `build/` instead of being rebuilt and deleted every build.
- Per-object disassembly is opt-in behind `DUMP_OBJS=1`. It was adding ~600MB to `build/` and a few seconds to every clean build.
- Raplaced `-g3` with `-g2`. `-g3` emits macro definitions, which cost object size and aren't used by the addr2line in `teensy4/CrashReport.cpp`.
- files in `src/` had includes that only resolved because every subdirectory of `src/` was on the search path. They're relative to `src/` now.
- `LIBRARY_INC_DIRS` no longer uses `find -maxdepth 2`, which pulled in directories that aren't include roots and emitted malformed `-isystem` paths.
- Separate `.elf`, `.hex`, and `dump` targets
- `FEATURE_DEFINES` replaces the commented-out `#define`s scattered in source files. Set it at the top of the Makefile.
- Build artifacts stay in build/ now, no more `firmware.hex` and `firmware.elf` in the repo root
- clangd is now decoupled from normal builds. Run `make clangd` if you use clangd.