### PR TITLE
Match clangd 32-bit types to ARM GCC

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,7 @@
 CompileFlags:
+  Add:
+    - -U__INT32_TYPE__
+    - "-D__INT32_TYPE__=long int"
+    - -U__UINT32_TYPE__
+    - "-D__UINT32_TYPE__=long unsigned int"
   Remove: [--specs=*]


### PR DESCRIPTION
Updates clangd’s 32-bit type definitions to match the ARM GCC toolchain. Fixes this clangd error on headers that include Arduino.h:

```
In included file: functions that differ only in their return type cannot be overloadedclang(ovl\_diff\_return\_type)
WProgram.h(103, 9): Error occurred here
stdlib.h(260, 6): Previous declaration is here
```